### PR TITLE
Callbacks on window

### DIFF
--- a/docs/API/GLFW/glfwCreateWindow.md
+++ b/docs/API/GLFW/glfwCreateWindow.md
@@ -73,8 +73,7 @@ arguments
 
 returns
 
-:    `\GLFWwindow` The handle of the created window, or `NULL` if an
-`error` occurred.
+:    `\GLFWwindow` 
 
 ---
      

--- a/docs/API/GLFW/glfwSetCharModsCallback.md
+++ b/docs/API/GLFW/glfwSetCharModsCallback.md
@@ -1,0 +1,43 @@
+# glfwSetCharModsCallback
+This function sets the character with modifiers callback of the specified
+window, which is called when a Unicode character is input regardless of what
+modifier keys are used.
+
+```php
+function glfwSetCharModsCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+The character with modifiers callback is intended for implementing custom
+Unicode character input. For regular Unicode text input, see the character
+callback.
+
+Example:
+```php
+glfwSetCharModsCallback($window, function($codepoint, $mods) {
+    echo "Character: " . mb_chr($codepoint) . ' with mods: ' . $mods .
+PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetCursorEnterCallback.md
+++ b/docs/API/GLFW/glfwSetCursorEnterCallback.md
@@ -1,0 +1,42 @@
+# glfwSetCursorEnterCallback
+This function sets the cursor boundary crossing callback of the specified
+window, which is called when the cursor enters or leaves the client area of
+the window.
+
+```php
+function glfwSetCursorEnterCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetCursorEnterCallback($window, function($entered) {
+    if ($entered) {
+        echo "Cursor entered window" . PHP_EOL;
+    } else {
+        echo "Cursor left window" . PHP_EOL;
+    }
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetCursorPosCallback.md
+++ b/docs/API/GLFW/glfwSetCursorPosCallback.md
@@ -1,0 +1,40 @@
+# glfwSetCursorPosCallback
+This function sets the cursor position callback of the specified window,
+which is called when the cursor is moved.
+
+```php
+function glfwSetCursorPosCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+The callback is provided with the position, in screen coordinates, relative
+to the upper-left corner of the client area of the window.
+
+Example:
+```php
+glfwSetCursorPosCallback($window, function($xpos, $ypos) {
+    echo "Cursor position: " . $xpos . ", " . $ypos . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetDropCallback.md
+++ b/docs/API/GLFW/glfwSetDropCallback.md
@@ -1,0 +1,40 @@
+# glfwSetDropCallback
+This function sets the file drop callback of the specified window, which is
+called when one or more dragged files are dropped on the window.
+
+```php
+function glfwSetDropCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetDropCallback($window, function($paths) {
+    echo "Dropped files:" . PHP_EOL;
+    foreach ($paths as $path) {
+        echo "  " . $path . PHP_EOL;
+    }
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetFramebufferSizeCallback.md
+++ b/docs/API/GLFW/glfwSetFramebufferSizeCallback.md
@@ -1,0 +1,41 @@
+# glfwSetFramebufferSizeCallback
+This function sets the framebuffer resize callback of the specified window,
+which is called when the framebuffer of the specified window is resized.
+
+```php
+function glfwSetFramebufferSizeCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+This callback is provided for convenience.  The equivalent functionality can
+be achieved by registering a window size callback and querying the
+framebuffer size within that callback.
+
+Example:
+```php
+glfwSetFramebufferSizeCallback($window, function($width, $height) {
+    echo "Framebuffer size changed to: " . $width . "x" . $height . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetMouseButtonCallback.md
+++ b/docs/API/GLFW/glfwSetMouseButtonCallback.md
@@ -1,0 +1,45 @@
+# glfwSetMouseButtonCallback
+This function sets the mouse button callback of the specified window, which
+is called when a mouse button is pressed or released.
+
+```php
+function glfwSetMouseButtonCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetMouseButtonCallback($window, function($button, $action, $mods) {
+    if ($button == GLFW_MOUSE_BUTTON_LEFT && $action == GLFW_PRESS) {
+        echo "Left mouse button pressed" . PHP_EOL;
+    }
+});
+```
+
+When a window loses input focus, it will generate synthetic mouse button
+release events for all pressed mouse buttons. You can tell these events from
+user-generated events by the fact that the synthetic ones are generated after
+the focus loss event has been processed, i.e. after the window focus callback
+has been called.
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetScrollCallback.md
+++ b/docs/API/GLFW/glfwSetScrollCallback.md
@@ -1,0 +1,38 @@
+# glfwSetScrollCallback
+This function sets the scroll callback of the specified window, which is
+called when a scrolling device is used, such as a mouse wheel or scrolling
+area of a touchpad.
+
+```php
+function glfwSetScrollCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetScrollCallback($window, function($xoffset, $yoffset) {
+    echo "Scroll offset: " . $xoffset . ", " . $yoffset . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowCloseCallback.md
+++ b/docs/API/GLFW/glfwSetWindowCloseCallback.md
@@ -1,0 +1,43 @@
+# glfwSetWindowCloseCallback
+This function sets the close callback of the specified window, which is
+called when the user attempts to close the window, for example by clicking
+the close widget in the title bar.
+
+```php
+function glfwSetWindowCloseCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+The close flag is set before this callback is called, but you can modify it
+at any time with glfwSetWindowShouldClose.
+
+The close callback is not triggered by glfwDestroyWindow.
+
+Example:
+```php
+glfwSetWindowCloseCallback($window, function() {
+    echo "Window close requested" . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowContentScaleCallback.md
+++ b/docs/API/GLFW/glfwSetWindowContentScaleCallback.md
@@ -1,0 +1,42 @@
+# glfwSetWindowContentScaleCallback
+This function sets the window content scale callback of the specified window,
+which is called when the content scale of the specified window changes.
+
+```php
+function glfwSetWindowContentScaleCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+This callback is provided for convenience.  The equivalent functionality can
+be achieved by registering a window size callback and querying the content
+scale within that callback.
+
+Example:
+```php
+glfwSetWindowContentScaleCallback($window, function($xscale, $yscale) {
+    echo "Window content scale changed to: " . $xscale . "x" . $yscale .
+PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowFocusCallback.md
+++ b/docs/API/GLFW/glfwSetWindowFocusCallback.md
@@ -1,0 +1,42 @@
+# glfwSetWindowFocusCallback
+This function sets the focus callback of the specified window, which is
+called when the window gains or loses input focus.
+
+```php
+function glfwSetWindowFocusCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+After the focus callback is called for a window that lost input focus,
+synthetic key and mouse button release events will be generated for all such
+that had been pressed.  For more information, see glfwSetKeyCallback and
+glfwSetMouseButtonCallback.
+
+Example:
+```php
+glfwSetWindowFocusCallback($window, function($focused) {
+    echo "Window focus changed to: " . $focused . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowIconifyCallback.md
+++ b/docs/API/GLFW/glfwSetWindowIconifyCallback.md
@@ -1,0 +1,37 @@
+# glfwSetWindowIconifyCallback
+This function sets the iconification callback of the specified window, which
+is called when the window is iconified or restored.
+
+```php
+function glfwSetWindowIconifyCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetWindowIconifyCallback($window, function($iconified) {
+    echo "Window iconified changed to: " . $iconified . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowMaximizeCallback.md
+++ b/docs/API/GLFW/glfwSetWindowMaximizeCallback.md
@@ -1,0 +1,37 @@
+# glfwSetWindowMaximizeCallback
+This function sets the maximize callback of the specified window, which is
+called when the window is maximized or restored.
+
+```php
+function glfwSetWindowMaximizeCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+Example:
+```php
+glfwSetWindowMaximizeCallback($window, function($maximized) {
+    echo "Window maximized changed to: " . $maximized . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowPosCallback.md
+++ b/docs/API/GLFW/glfwSetWindowPosCallback.md
@@ -1,0 +1,40 @@
+# glfwSetWindowPosCallback
+This function sets the position callback of the specified window, which is
+called when the window is moved.
+
+```php
+function glfwSetWindowPosCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+The callback is provided with the screen position of the upper-left corner of
+the client area of the window.
+
+Example:
+```php
+glfwSetWindowPosCallback($window, function($x, $y) {
+    echo "Window moved to: " . $x . ", " . $y . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowRefreshCallback.md
+++ b/docs/API/GLFW/glfwSetWindowRefreshCallback.md
@@ -1,0 +1,42 @@
+# glfwSetWindowRefreshCallback
+This function sets the refresh callback of the specified window, which is
+called when the client area of the window needs to be redrawn, for example if
+the window has been exposed after having been covered by another window.
+
+```php
+function glfwSetWindowRefreshCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
+the window contents are saved off-screen, this callback may be called only
+very infrequently or never at all.
+
+Example:
+```php
+glfwSetWindowRefreshCallback($window, function() {
+    echo "Window needs to be redrawn" . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/API/GLFW/glfwSetWindowSizeCallback.md
+++ b/docs/API/GLFW/glfwSetWindowSizeCallback.md
@@ -1,0 +1,40 @@
+# glfwSetWindowSizeCallback
+This function sets the size callback of the specified window, which is called
+when the window is resized.
+
+```php
+function glfwSetWindowSizeCallback(\GLFWwindow $window, callable $callback) : void
+```
+
+The callback is provided with the size, in screen coordinates, of the client
+area of the window.
+
+Example:
+```php
+glfwSetWindowSizeCallback($window, function($width, $height) {
+    echo "Window resized to: " . $width . "x" . $height . PHP_EOL;
+});
+```
+
+arguments
+
+:    1. `\GLFWwindow` `$window` The window whose callback to set.
+    2. `callable` `$callback` 
+
+returns
+
+:    `void` 
+
+---
+     
+
+!!! cite "Copyright"
+
+    This documentation page is prased from the `glfw3.h` header file, and only modified to fit 
+    the PHP-GFLW extension bindings. The original documentation copyright is as follows:
+
+    ```
+    Copyright (c) 2002-2006 Marcus Geelnard
+    Copyright (c) 2006-2019 Camilla Löwy
+    https://www.glfw.org/license
+    ```

--- a/docs/user-guide/debug_opengl_with_apitrace.md
+++ b/docs/user-guide/debug_opengl_with_apitrace.md
@@ -1,0 +1,32 @@
+# Debug OpenGL calls with apitrace
+
+Every OpenGL developer will sooner or later end up in a situation where they only see a black screen or a crash and they have no idea what is going wrong.  In this case it is often VERY useful to record the OpenGL calls and replay them in a debugger. There are a bunch of tools that can do this, but the one I like the most is [apitrace](http://apitrace.github.io/). Mostly because it is pretty straight forward to use and it is available for **all major platforms**.
+
+**Other tools**
+
+ * [NVIDIA Nsight](https://developer.nvidia.com/nsight-visual-studio-edition)<br>
+   My absolute favorite, but it is only available for Windows. 
+ * [RenderDoc](https://renderdoc.org/)
+ * [Intel GPA](https://www.intel.com/content/www/us/en/developer/tools/graphics-performance-analyzers/overview.html)<br>
+    I have not used this one, I think it only works with intel chips, please correct me if I am wrong.
+ * [glintercept](https://github.com/dtrebilco/glintercept)
+ * [vogl](https://github.com/ValveSoftware/vogl)
+
+ ## Trace calls
+
+Tracing a PHP OpenGL application is no different than tracing a C++ OpenGL application. 
+
+```bash
+apitrace trace --api gl php my_php_application.php
+```
+
+This will launch your application and create a file called `php.trace` in the current directory. This file contains all the OpenGL calls that were made during the execution of the PHP script.
+
+## Inspect calls
+
+To inspect the calls you can use the `qapitrace` command. This will open a GUI that allows you to inspect the calls. 
+
+```bash
+qapitrace php.trace
+```
+

--- a/examples/04_instancing.php
+++ b/examples/04_instancing.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * This example will open a window and draw a 3D cube in it.
  * We utilize the example helpers here to focus on what matter in this specifc example.
  */
 require __DIR__ . '/99_example_helpers.php';

--- a/examples/05_objloading.php
+++ b/examples/05_objloading.php
@@ -97,7 +97,7 @@ glEnable(GL_DEPTH_TEST);
 
 // capture keyboard events to toggle rendering modes
 $wireframe = false;
-glfwSetKeyCallback($window, function ($key, $scancode, $action, $mods) use (&$wireframe) {
+glfwSetKeyCallback($window, function ($key, $scancode, $action, $mods) use (&$wireframe, $window) {
     if ($key == GLFW_KEY_ESCAPE && $action == GLFW_PRESS) {
         glfwSetWindowShouldClose($window, true);
     }

--- a/examples/05_objloading.php
+++ b/examples/05_objloading.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * This example will open a window and draw a 3D cube in it.
  * We utilize the example helpers here to focus on what matter in this specifc example.
  */
 require __DIR__ . '/99_example_helpers.php';

--- a/examples/06_basic_light.php
+++ b/examples/06_basic_light.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * This example will open a window and draw a 3D cube in it.
  * We utilize the example helpers here to focus on what matter in this specifc example.
  */
 require __DIR__ . '/99_example_helpers.php';

--- a/examples/07_text_rendering.php
+++ b/examples/07_text_rendering.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * This example will open a window and draw a 3D cube in it.
  * We utilize the example helpers here to focus on what matter in this specifc example.
  */
 require __DIR__ . '/99_example_helpers.php';

--- a/examples/08_input_and_events.php
+++ b/examples/08_input_and_events.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This example shows all the window and input callback at work
+ * by simply printing the eventс to the console.
+ */
+require __DIR__ . '/99_example_helpers.php';
+
+
+// ensure mbstring extensin is loaded, we need it for the text rendering
+if (!extension_loaded('mbstring')) {
+    throw new \Exception('mbstring extension is required for this example');
+}
+
+$window = ExampleHelper::begin();
+
+glfwSetKeyCallback($window, function ($key1, $scancode2, $action3, $mods4) use ($window) {
+    if ($key1 == GLFW_KEY_ESCAPE && $action3 == GLFW_PRESS) {
+        glfwSetWindowShouldClose($window, GL_TRUE);
+    }
+});
+
+glfwSetWindowPosCallback($window, function($x, $y) {
+    echo "Window moved to: " . $x . ", " . $y . PHP_EOL;
+});
+
+glfwSetWindowSizeCallback($window, function($width, $height) {
+    echo "Window resized to: " . $width . ", " . $height . PHP_EOL;
+});
+
+glfwSetWindowCloseCallback($window, function() {
+    echo "Window close requested" . PHP_EOL;
+});
+
+glfwSetWindowRefreshCallback($window, function() {
+    echo "Window refresh requested" . PHP_EOL;
+});
+
+glfwSetWindowFocusCallback($window, function($focused) {
+    echo "Window focus changed to: " . $focused . PHP_EOL;
+});
+
+glfwSetWindowIconifyCallback($window, function($iconified) {
+    echo "Window iconified changed to: " . $iconified . PHP_EOL;
+});
+
+glfwSetFramebufferSizeCallback($window, function($width, $height) {
+    echo "Framebuffer resized to: " . $width . ", " . $height . PHP_EOL;
+});
+
+glfwSetWindowContentScaleCallback($window, function($x, $y) {
+    echo "Window content scale changed to: " . $x . ", " . $y . PHP_EOL;
+});
+
+glfwSetCharModsCallback($window, function($codepoint, $mods) {
+    echo "Character: " . mb_chr($codepoint) . ' with mods: ' . $mods . PHP_EOL;
+});
+
+glfwSetMouseButtonCallback($window, function($button, $action, $mods) {
+    echo "Mouse button: " . $button . ' action: ' . $action . ' with mods: ' . $mods . PHP_EOL;
+});
+
+glfwSetCursorPosCallback($window, function($x, $y) {
+    echo "Mouse cursor moved to: " . $x . ", " . $y . PHP_EOL;
+});
+
+glfwSetCursorEnterCallback($window, function($entered) {
+    if ($entered) {
+        echo "Mouse cursor entered window" . PHP_EOL;
+    } else {
+        echo "Mouse cursor left window" . PHP_EOL;
+    }
+});
+
+glfwSetScrollCallback($window, function($x, $y) {
+    echo "Mouse scrolled: " . $x . ", " . $y . PHP_EOL;
+});
+
+glfwSetDropCallback($window, function($count, $paths) {
+    echo "Dropped " . $count . " files:" . PHP_EOL;
+    for ($i = 0; $i < $count; $i++) {
+        echo " -> File " . $i . ": " . $paths[$i] . PHP_EOL;
+    }
+});
+
+// print some help to the console
+echo str_repeat('-', 80) . PHP_EOL;
+echo '-> Press ESC to close the window' . PHP_EOL;
+echo '-> This example shows all the window and input callback at work' . PHP_EOL;
+echo str_repeat('-', 80) . PHP_EOL;
+
+while (!glfwWindowShouldClose($window))
+{
+    glfwPollEvents();
+    glClearColor(0.2, 0.3, 0.3, 1.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glfwSwapBuffers($window);
+}
+
+ExampleHelper::stop($window);

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,20 @@
 # Examples 
 
-  * [1. Hello World](#1-hello-world)
-  * [2. 3D Cube](#2-3d-cube)
-  * [3. Textured Cube](#3-textured-cube)
-  * [4. Instanced Rendering](#4-instanced-rendering)
-  * [5. Object file loading](#5-object-file-loading)
-  * [6. Simple lighting](#6-simple-lighting)
-  * [7. Text Rendering](#7-text-rendering)
+ * [1. Hello World](#1-hello-world)
+ * [2. 3D Cube](#2-3d-cube)
+ * [3. Textured Cube](#3-textured-cube)
+ * [4. Instanced Rendering](#4-instanced-rendering)
+ * [5. Object file loading](#5-object-file-loading)
+ * [6. Simple lighting](#6-simple-lighting)
+ * [7. Text Rendering](#7-text-rendering)
+ * [8. Input And Events](#8-input-and-events)
 
 ## 1. Hello World
+
+This is the most basic example of how to use the GLFW library.
+You can think of it as a ""Hello World"" example. In this example, we create a window and render a triangle.
+
+This example does not utilize our helper class to keep it as basic as possible.
 
 > Code: [01_triangle.php](./01_triangle.php)!
 
@@ -16,11 +22,15 @@
 
 ## 2. 3D Cube
 
+This example shows how to render a 3D cube using PHP OpenGL.
+
 > Code: [02_3D_cube.php](./02_3D_cube.php)!
 
 https://user-images.githubusercontent.com/956212/183306744-3b345bc8-7010-4e68-94c2-29a335102ce4.mov
 
 ## 3. Textured Cube
+
+This example shows how to render a textured cube using PHP OpenGL. It provides an example of how to load a texture from a file and how to use it in a shader using the PHP-GLFW `GL\Texture\Texture2D` class.
 
 > Code: [03_textured_cube.php](./03_textured_cube.php)!
 
@@ -28,11 +38,15 @@ https://user-images.githubusercontent.com/956212/183306784-c85c2b03-ed6f-4070-a4
 
 ## 4. Instanced Rendering 
 
+This example shows how to render multiple instances of a single object using PHP OpenGL. It is just a basic example of how to use instanced rendering.
+
 > Code: [04_instancing.php](./04_instancing.php)!
 
 https://user-images.githubusercontent.com/956212/183306836-4b5a06c6-5fdf-40eb-a038-b413af177b77.mov
 
 ## 5. Object file loading
+
+This example shows how to load a 3D object from a file using PHP OpenGL. It displays how to utilize the `\GL\Geometry\ObjFileParser` class to load a 3D object from a file and how to render it.
 
 > Code: [05_objloading.php](./05_objloading.php)!
 
@@ -40,13 +54,23 @@ https://user-images.githubusercontent.com/956212/183306836-4b5a06c6-5fdf-40eb-a0
 
 ## 6. Simple lighting 
 
+This example shows how to render a 3D object with simple lighting using PHP OpenGL. 
+
 > Code: [06_basic_light.php](./06_basic_light.php)!
 
 <img width="512" alt="s" src="https://user-images.githubusercontent.com/956212/190879015-59616d84-b23e-4319-93b2-9c53c423f6b6.png">
 
 ## 7. Text Rendering
 
+This example shows how to render text using PHP OpenGL. It uses a simple bitmap font to render text on the screen.
+
 > Code: [07_text_rendering.php](./07_text_rendering.php)!
 
 <img width="512" alt="s" src="https://user-images.githubusercontent.com/956212/190903240-6f144bf0-77dd-4af9-a293-6e7e8ee5c198.png">
+
+## 8. Input And Events
+
+This example shows how to handle input and events using PHP OpenGL. It implements all available input and window event callbacks and prints them to the console.
+
+> Code: [08_input_and_events.php](./08_input_and_events.php)!
 

--- a/generator/build
+++ b/generator/build
@@ -21,6 +21,11 @@ $reader->parse($spec, __DIR__ . '/data/gl.xml', __DIR__ . '/data/glrefs.json');
 $gen->import($spec, 'gl', '4.1', [
     'glShaderSource', // custom implementation
     'glBufferData', // custom implementation
+    'glGetSynciv', // currently not supported
+    'glWaitSync', // currently not supported
+    'glDeleteSync', // currently not supported
+    'glFenceSync', // currently not supported
+    'glClientWaitSync', // currently not supported
 ]);
 
 // parse the glfw header
@@ -53,6 +58,7 @@ $gen->adjust(PHPGlfwAdjustments\GLFWDestroyFunctionAdjustment::class);
 $gen->adjust(PHPGlfwAdjustments\GLFWGladLoader::class);
 $gen->adjust(PHPGlfwAdjustments\GLFWSwapBuffersAdjustment::class);
 $gen->adjust(PHPGlfwAdjustments\GLFWCallbacksAdjustment::class);
+$gen->adjust(PHPGlfwAdjustments\GLFWCreateWindowAdjustment::class);
 $gen->adjust(PHPGlfwAdjustments\GLShaderSourceAdjustment::class);
 $gen->adjust(PHPGlfwAdjustments\GLBufferDataAdjustment::class);
 $gen->adjust(PHPGlfwAdjustments\GLVertexAttribPointerAdjustment::class);

--- a/generator/src/ExtInternalPtrObject.php
+++ b/generator/src/ExtInternalPtrObject.php
@@ -17,11 +17,18 @@ class ExtInternalPtrObject
 
     /**
      * An array of Zvals that should be added to the object,
-     * i use this to store the callback functions for example
      * 
      * @var array
      */
     public array $additionalZvals = [];
+
+    /**
+     * An array of (zend_fcall_info, zend_fcall_info_cache) pairs
+     * I use this to store the window & input callback functions for example
+     * 
+     * @var array
+     */
+    public array $additionalCallbacks = [];
 
     /**
      * Constructor

--- a/generator/src/ExtInternalPtrObject.php
+++ b/generator/src/ExtInternalPtrObject.php
@@ -16,6 +16,14 @@ class ExtInternalPtrObject
     public string $type;
 
     /**
+     * An array of Zvals that should be added to the object,
+     * i use this to store the callback functions for example
+     * 
+     * @var array
+     */
+    public array $additionalZvals = [];
+
+    /**
      * Constructor
      */
     public function __construct(string $name, string $type) 

--- a/generator/src/GLFWHeaderParser.php
+++ b/generator/src/GLFWHeaderParser.php
@@ -39,7 +39,7 @@ class GLFWHeaderParser
                 'windowiconifycallback',
                 'windowmaximizecallback',
                 'windowframebuffersizecallback',
-                'windowcontentcalecallback',
+                'windowcontentscalecallback',
 
                 // input 
                 'keycallback',

--- a/generator/src/GLFWHeaderParser.php
+++ b/generator/src/GLFWHeaderParser.php
@@ -31,15 +31,15 @@ class GLFWHeaderParser
         {
             public array $additionalCallbacks = [
                 // window callbacks
-                'poscallback',
-                'sizecallback',
-                'closecallback',
-                'refreshcallback',
-                'focuscallback',
-                'iconifycallback',
-                'maximizecallback',
-                'framebuffersizecallback',
-                'contentcalecallback',
+                'windowposcallback',
+                'windowsizecallback',
+                'windowclosecallback',
+                'windowrefreshcallback',
+                'windowfocuscallback',
+                'windowiconifycallback',
+                'windowmaximizecallback',
+                'windowframebuffersizecallback',
+                'windowcontentcalecallback',
 
                 // input 
                 'keycallback',

--- a/generator/src/GLFWHeaderParser.php
+++ b/generator/src/GLFWHeaderParser.php
@@ -29,7 +29,7 @@ class GLFWHeaderParser
     {
         $extGen->addIPO(new class('GLFWwindow', 'GLFWwindow*') extends ExtInternalPtrObject 
         {
-            public array $additionalZvals = [
+            public array $additionalCallbacks = [
                 // window callbacks
                 'poscallback',
                 'sizecallback',

--- a/generator/src/GLFWHeaderParser.php
+++ b/generator/src/GLFWHeaderParser.php
@@ -27,7 +27,31 @@ class GLFWHeaderParser
 
     private function createIPODefinitions(ExtGenerator $extGen)
     {
-        $extGen->addIPO(new class('GLFWwindow', 'GLFWwindow*') extends ExtInternalPtrObject {
+        $extGen->addIPO(new class('GLFWwindow', 'GLFWwindow*') extends ExtInternalPtrObject 
+        {
+            public array $additionalZvals = [
+                // window callbacks
+                'poscallback',
+                'sizecallback',
+                'closecallback',
+                'refreshcallback',
+                'focuscallback',
+                'iconifycallback',
+                'maximizecallback',
+                'framebuffersizecallback',
+                'contentcalecallback',
+
+                // input 
+                'keycallback',
+                'charcallback',
+                'charmodscallback',
+                'mousebuttoncallback',
+                'cursorposcallback',
+                'cursorentercallback',
+                'scrollcallback',
+                'dropcallback',
+            ];
+
             public function getDestructionCall(string $var) : string {
                 return "glfwDestroyWindow($var);";
             }

--- a/generator/src/PHPGlfwAdjustments/GLFWCallbacksAdjustment.php
+++ b/generator/src/PHPGlfwAdjustments/GLFWCallbacksAdjustment.php
@@ -39,122 +39,6 @@ EOD;
 
 
     /**
-     * GLFW Key Callback 
-     * 
-     * ------------------------------------------------------------------------------------------------------
-     */
-    private function patchGlfwSetKeyCallback(ExtGenerator $gen) : void
-    {
-        $functionName = 'glfwSetKeyCallback';
-
-        $func = new class($functionName) extends ExtFunction 
-        {
-            public function getFunctionImplementationBody(): string
-            {
-
-                $buffer = <<<EOD
-zend_fcall_info fci;
-zend_fcall_info_cache fcc;
-zval *window_zval;
-
-if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
-    RETURN_THROWS();
-}
-
-phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
-
-// copy the function info over to the window object
-// obj_ptr->keycallback.fci = fci;
-// obj_ptr->keycallback.fci_cache = fcc;
-
-// this fixes a segfault when the callback has a reference over `use()`
-// i honestly have no idea why this works, but it does
-Z_TRY_ADDREF(fci.function_name);
-if (fcc.object) {
-    GC_ADDREF(fcc.object);
-}
-
-memcpy((void*)&obj_ptr->keycallback.fci, (void*)&fci, sizeof(zend_fcall_info));
-memcpy((void*)&obj_ptr->keycallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
-
-glfwSetKeyCallback(obj_ptr->glfwwindow, phpglfw_callback_keycallback_handler);
-EOD;
-                return $buffer;
-            }
-        };
-
-        // copy base function into our new one and replace it in the extension
-        $baseFunc = $gen->getFunctionByName($functionName);
-        $func->copyFrom($baseFunc);
-
-        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
-
-        $func->comment = <<<EOD
-This function sets the key callback of the specified window, which is called when a key is pressed, repeated or released.
-
-Example: 
-```php
-glfwSetKeyCallback(\$window, function(\$key, \$scancode, \$action, \$mods) use(\$window) {
-	if (\$key == GLFW_KEY_ESCAPE && \$action == GLFW_PRESS) {
-		glfwSetWindowShouldClose(\$window, GL_TRUE);
-	}
-});
-```
-
-The key functions deal with physical keys, with layout independent key tokens named after their values in the standard US keyboard layout. If you want to input text, use the character callback instead.
-
-When a window loses input focus, it will generate synthetic key release events for all pressed keys. You can tell these events from user-generated events by the fact that the synthetic ones are generated after the focus loss event has been processed, i.e. after the window focus callback has been called.
-
-The scancode of a key is specific to that platform or sometimes even to that machine. Scancodes are intended to allow users to bind keys that don't have a GLFW key token. Such keys have key set to GLFW_KEY_UNKNOWN, their state is not saved and so it cannot be queried with glfwGetKey.
-
-Sometimes GLFW needs to generate synthetic key events, in which case the scancode may be zero.
-EOD;
-
-        $gen->replaceFunctionByName($func);
-    }
-
-    /**
-     * GLFW CHAR Callback 
-     * 
-     * ------------------------------------------------------------------------------------------------------
-     */
-    private function patchGlfwSetCharCallback(ExtGenerator $gen) : void
-    {
-        $functionName = 'glfwSetCharCallback';
-
-        $func = new class($functionName) extends ExtFunction 
-        {
-            public function getFunctionImplementationBody(): string
-            {
-                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_charcallback_handler', 'charcallback', 'glfwSetCharCallback');
-            }
-        };
-
-        // copy base function into our new one and replace it in the extension
-        $baseFunc = $gen->getFunctionByName($functionName);
-        $func->copyFrom($baseFunc);
-
-        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
-
-        $func->comment = <<<EOD
-This function sets the character callback of the specified window, which is called when a Unicode character is input.
-
-Example:
-```php
-glfwSetCharCallback(\$window, function(\$codepoint) {
-    echo "Character: " . mb_chr(\$codepoint) . PHP_EOL;
-});
-```
-
-The character callback is intended for Unicode text input. As it deals with characters, it is keyboard layout dependent, whereas the key callback is not. Characters do not map 1:1 to physical keys, as a key may produce zero, one or more characters. If you want to know whether a specific physical key was pressed or released, see the key callback instead.
-
-The character callback behaves as system text input normally does and will not be called if modifier keys are held down that would prevent normal text input on that platform, for example a Super (Command) key on macOS or Alt key on Windows.
-
-EOD;
-        $gen->replaceFunctionByName($func);
-    }
-
-    /**
      * GLFW Window position Callback 
      * 
      * ------------------------------------------------------------------------------------------------------
@@ -504,14 +388,365 @@ EOD;
     }
 
     /**
+     * GLFW Key Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetKeyCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetKeyCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+
+                $buffer = <<<EOD
+zend_fcall_info fci;
+zend_fcall_info_cache fcc;
+zval *window_zval;
+
+if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+    RETURN_THROWS();
+}
+
+phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+
+// copy the function info over to the window object
+// obj_ptr->keycallback.fci = fci;
+// obj_ptr->keycallback.fci_cache = fcc;
+
+// this fixes a segfault when the callback has a reference over `use()`
+// i honestly have no idea why this works, but it does
+Z_TRY_ADDREF(fci.function_name);
+if (fcc.object) {
+    GC_ADDREF(fcc.object);
+}
+
+memcpy((void*)&obj_ptr->keycallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+memcpy((void*)&obj_ptr->keycallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+
+glfwSetKeyCallback(obj_ptr->glfwwindow, phpglfw_callback_keycallback_handler);
+EOD;
+                return $buffer;
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the key callback of the specified window, which is called when a key is pressed, repeated or released.
+
+Example: 
+```php
+glfwSetKeyCallback(\$window, function(\$key, \$scancode, \$action, \$mods) use(\$window) {
+	if (\$key == GLFW_KEY_ESCAPE && \$action == GLFW_PRESS) {
+		glfwSetWindowShouldClose(\$window, GL_TRUE);
+	}
+});
+```
+
+The key functions deal with physical keys, with layout independent key tokens named after their values in the standard US keyboard layout. If you want to input text, use the character callback instead.
+
+When a window loses input focus, it will generate synthetic key release events for all pressed keys. You can tell these events from user-generated events by the fact that the synthetic ones are generated after the focus loss event has been processed, i.e. after the window focus callback has been called.
+
+The scancode of a key is specific to that platform or sometimes even to that machine. Scancodes are intended to allow users to bind keys that don't have a GLFW key token. Such keys have key set to GLFW_KEY_UNKNOWN, their state is not saved and so it cannot be queried with glfwGetKey.
+
+Sometimes GLFW needs to generate synthetic key events, in which case the scancode may be zero.
+EOD;
+
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW CHAR Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetCharCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetCharCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_charcallback_handler', 'charcallback', 'glfwSetCharCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the character callback of the specified window, which is called when a Unicode character is input.
+
+Example:
+```php
+glfwSetCharCallback(\$window, function(\$codepoint) {
+    echo "Character: " . mb_chr(\$codepoint) . PHP_EOL;
+});
+```
+
+The character callback is intended for Unicode text input. As it deals with characters, it is keyboard layout dependent, whereas the key callback is not. Characters do not map 1:1 to physical keys, as a key may produce zero, one or more characters. If you want to know whether a specific physical key was pressed or released, see the key callback instead.
+
+The character callback behaves as system text input normally does and will not be called if modifier keys are held down that would prevent normal text input on that platform, for example a Super (Command) key on macOS or Alt key on Windows.
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW CHAR mods Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetCharModsCallback(ExtGenerator $gen) : void 
+    {
+        $functionName = 'glfwSetCharModsCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_charmodscallback_handler', 'charmodscallback', 'glfwSetCharModsCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the character with modifiers callback of the specified window, which is called when a Unicode character is input regardless of what modifier keys are used.
+
+The character with modifiers callback is intended for implementing custom Unicode character input. For regular Unicode text input, see the character callback.
+
+Example:
+```php
+glfwSetCharModsCallback(\$window, function(\$codepoint, \$mods) {
+    echo "Character: " . mb_chr(\$codepoint) . ' with mods: ' . \$mods . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Mouse button Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetMouseButtonCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetMouseButtonCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_mousebuttoncallback_handler', 'mousebuttoncallback', 'glfwSetMouseButtonCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the mouse button callback of the specified window, which is called when a mouse button is pressed or released.
+
+Example:
+```php
+glfwSetMouseButtonCallback(\$window, function(\$button, \$action, \$mods) {
+    if (\$button == GLFW_MOUSE_BUTTON_LEFT && \$action == GLFW_PRESS) {
+        echo "Left mouse button pressed" . PHP_EOL;
+    }
+});
+```
+
+When a window loses input focus, it will generate synthetic mouse button release events for all pressed mouse buttons. You can tell these events from user-generated events by the fact that the synthetic ones are generated after the focus loss event has been processed, i.e. after the window focus callback has been called.
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Cursor position Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetCursorPosCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetCursorPosCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_cursorposcallback_handler', 'cursorposcallback', 'glfwSetCursorPosCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the cursor position callback of the specified window, which is called when the cursor is moved.
+
+The callback is provided with the position, in screen coordinates, relative to the upper-left corner of the client area of the window.
+
+Example:
+```php
+glfwSetCursorPosCallback(\$window, function(\$xpos, \$ypos) {
+    echo "Cursor position: " . \$xpos . ", " . \$ypos . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Cursor enter Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetCursorEnterCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetCursorEnterCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_cursorentercallback_handler', 'cursorentercallback', 'glfwSetCursorEnterCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the cursor boundary crossing callback of the specified window, which is called when the cursor enters or leaves the client area of the window.
+
+Example:
+```php
+glfwSetCursorEnterCallback(\$window, function(\$entered) {
+    if (\$entered) {
+        echo "Cursor entered window" . PHP_EOL;
+    } else {
+        echo "Cursor left window" . PHP_EOL;
+    }
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Scroll Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetScrollCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetScrollCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_scrollcallback_handler', 'scrollcallback', 'glfwSetScrollCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the scroll callback of the specified window, which is called when a scrolling device is used, such as a mouse wheel or scrolling area of a touchpad.
+
+Example:
+```php
+glfwSetScrollCallback(\$window, function(\$xoffset, \$yoffset) {
+    echo "Scroll offset: " . \$xoffset . ", " . \$yoffset . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Drop Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetDropCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetDropCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_dropcallback_handler', 'dropcallback', 'glfwSetDropCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the file drop callback of the specified window, which is called when one or more dragged files are dropped on the window.
+
+Example:
+```php
+glfwSetDropCallback(\$window, function(\$paths) {
+    echo "Dropped files:" . PHP_EOL;
+    foreach (\$paths as \$path) {
+        echo "  " . \$path . PHP_EOL;
+    }
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
      * Recieves an instance of the extension generator before beeing built to 
      * make changes / adjustments for the extension to handle edge cases whithout 
      * adding a million ifs into the parser code.
      */
     public function handle(ExtGenerator $gen) : void
     {
-        $this->patchGlfwSetKeyCallback($gen);
-        $this->patchGlfwSetCharCallback($gen);
         $this->patchGlfwSetWindowPosCallback($gen);
         $this->patchGlfwSetWindowSizeCallback($gen);
         $this->patchGlfwSetWindowCloseCallback($gen);
@@ -522,6 +757,13 @@ EOD;
         $this->patchGlfwSetFramebufferSizeCallback($gen);
         $this->patchGlfwSetWindowContentScaleCallback($gen);
 
-
+        $this->patchGlfwSetKeyCallback($gen);
+        $this->patchGlfwSetCharCallback($gen);
+        $this->patchGlfwSetCharModsCallback($gen);
+        $this->patchGlfwSetMouseButtonCallback($gen);
+        $this->patchGlfwSetCursorPosCallback($gen);
+        $this->patchGlfwSetCursorEnterCallback($gen);
+        $this->patchGlfwSetScrollCallback($gen);
+        $this->patchGlfwSetDropCallback($gen);
     }
 }

--- a/generator/src/PHPGlfwAdjustments/GLFWCallbacksAdjustment.php
+++ b/generator/src/PHPGlfwAdjustments/GLFWCallbacksAdjustment.php
@@ -273,6 +273,235 @@ EOD;
         $gen->replaceFunctionByName($func);
     }
 
+    /**
+     * GLFW Window refresh Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetWindowRefreshCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetWindowRefreshCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowrefreshcallback_handler', 'windowrefreshcallback', 'glfwSetWindowRefreshCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the refresh callback of the specified window, which is called when the client area of the window needs to be redrawn, for example if the window has been exposed after having been covered by another window.
+
+On compositing window systems such as Aero, Compiz, Aqua or Wayland, where the window contents are saved off-screen, this callback may be called only very infrequently or never at all.
+
+Example:
+```php
+glfwSetWindowRefreshCallback(\$window, function() {
+    echo "Window needs to be redrawn" . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Window focus Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetWindowFocusCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetWindowFocusCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowfocuscallback_handler', 'windowfocuscallback', 'glfwSetWindowFocusCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the focus callback of the specified window, which is called when the window gains or loses input focus.
+
+After the focus callback is called for a window that lost input focus, synthetic key and mouse button release events will be generated for all such that had been pressed.  For more information, see glfwSetKeyCallback and glfwSetMouseButtonCallback.
+
+Example:
+```php
+glfwSetWindowFocusCallback(\$window, function(\$focused) {
+    echo "Window focus changed to: " . \$focused . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Window iconify Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetWindowIconifyCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetWindowIconifyCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowiconifycallback_handler', 'windowiconifycallback', 'glfwSetWindowIconifyCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the iconification callback of the specified window, which is called when the window is iconified or restored.
+
+Example:
+```php
+glfwSetWindowIconifyCallback(\$window, function(\$iconified) {
+    echo "Window iconified changed to: " . \$iconified . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Window maximize Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetWindowMaximizeCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetWindowMaximizeCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowmaximizecallback_handler', 'windowmaximizecallback', 'glfwSetWindowMaximizeCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the maximize callback of the specified window, which is called when the window is maximized or restored.
+
+Example:
+```php
+glfwSetWindowMaximizeCallback(\$window, function(\$maximized) {
+    echo "Window maximized changed to: " . \$maximized . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Window framebuffer resize Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetFramebufferSizeCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetFramebufferSizeCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowframebuffersizecallback_handler', 'windowframebuffersizecallback', 'glfwSetFramebufferSizeCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the framebuffer resize callback of the specified window, which is called when the framebuffer of the specified window is resized.
+
+This callback is provided for convenience.  The equivalent functionality can be achieved by registering a window size callback and querying the framebuffer size within that callback.
+
+Example:
+```php
+glfwSetFramebufferSizeCallback(\$window, function(\$width, \$height) {
+    echo "Framebuffer size changed to: " . \$width . "x" . \$height . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
+
+    /**
+     * GLFW Window content scale Callback 
+     * 
+     * ------------------------------------------------------------------------------------------------------
+     */
+    private function patchGlfwSetWindowContentScaleCallback(ExtGenerator $gen) : void
+    {
+        $functionName = 'glfwSetWindowContentScaleCallback';
+
+        $func = new class($functionName) extends ExtFunction 
+        {
+            public function getFunctionImplementationBody(): string
+            {
+                return GLFWCallbacksAdjustment::createCallbackImpl('phpglfw_callback_windowcontentscalecallback_handler', 'windowcontentscalecallback', 'glfwSetWindowContentScaleCallback');
+            }
+        };
+
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName($functionName);
+        $func->copyFrom($baseFunc);
+
+        $func->arguments[1] = ExtArgument::make('callback', ExtType::T_FUNC);
+
+        $func->comment = <<<EOD
+This function sets the window content scale callback of the specified window, which is called when the content scale of the specified window changes.
+
+This callback is provided for convenience.  The equivalent functionality can be achieved by registering a window size callback and querying the content scale within that callback.
+
+Example:
+```php
+glfwSetWindowContentScaleCallback(\$window, function(\$xscale, \$yscale) {
+    echo "Window content scale changed to: " . \$xscale . "x" . \$yscale . PHP_EOL;
+});
+```
+
+EOD;
+        $gen->replaceFunctionByName($func);
+    }
 
     /**
      * Recieves an instance of the extension generator before beeing built to 
@@ -286,6 +515,13 @@ EOD;
         $this->patchGlfwSetWindowPosCallback($gen);
         $this->patchGlfwSetWindowSizeCallback($gen);
         $this->patchGlfwSetWindowCloseCallback($gen);
+        $this->patchGlfwSetWindowRefreshCallback($gen);
+        $this->patchGlfwSetWindowFocusCallback($gen);
+        $this->patchGlfwSetWindowIconifyCallback($gen);
+        $this->patchGlfwSetWindowMaximizeCallback($gen);
+        $this->patchGlfwSetFramebufferSizeCallback($gen);
+        $this->patchGlfwSetWindowContentScaleCallback($gen);
+
 
     }
 }

--- a/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
+++ b/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
@@ -25,10 +25,11 @@ class GLFWCreateWindowAdjustment implements AdjustmentInterface
                 $b = parent::getFunctionImplementationBody() . PHP_EOL . PHP_EOL;
 
                 $b .= <<<EOD
+// fetch the internal object
+phpglfw_glfwwindow_object *intern = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
 // ensure user pointer is our internal window object
-zval *windowzval_userptr = NULL;
-ZVAL_COPY(windowzval_userptr, return_value);
-glfwSetWindowUserPointer(glfwwindow, windowzval_userptr);
+glfwSetWindowUserPointer(glfwwindow, intern);
 EOD;
                 return $b;
             }

--- a/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
+++ b/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
@@ -1,0 +1,42 @@
+<?php 
+
+namespace PHPGlfwAdjustments;
+
+use ExtFunction;
+use ExtGenerator;
+
+class GLFWCreateWindowAdjustment implements AdjustmentInterface
+{
+    /**
+     * Recieves an instance of the extension generator before beeing built to 
+     * make changes / adjustments for the extension to handle edge cases whithout 
+     * adding a million ifs into the parser code.
+     */
+    public function handle(ExtGenerator $gen) : void
+    {
+        /**
+         * We bind the window and input callbacks to our internal window object
+         * and forward events to the their hold zvals if they are set.
+         */
+        $func = new class('glfwCreateWindow') extends ExtFunction 
+        {    
+            public function getFunctionImplementationBody() : string
+            {
+                $b = parent::getFunctionImplementationBody() . PHP_EOL . PHP_EOL;
+
+                $b .= <<<EOD
+// ensure user pointer is our internal window object
+zval *windowzval_userptr = NULL;
+ZVAL_COPY(windowzval_userptr, return_value);
+glfwSetWindowUserPointer(glfwwindow, windowzval_userptr);
+EOD;
+                return $b;
+            }
+        };
+        
+        // copy base function into our new one and replace it in the extension
+        $baseFunc = $gen->getFunctionByName('glfwCreateWindow');
+        $func->copyFrom($baseFunc);
+        $gen->replaceFunctionByName($func);
+    }
+}

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -30,70 +30,6 @@
 #include "phpglfw_buffer.h"
 #include "phpglfw_math.h"
 #include <zend_API.h>
-    
-/**
- * ----------------------------------------------------------------------------
- * PHPGlfw Global callbacks
- * ----------------------------------------------------------------------------
- * Global callbacks like GLFWkeyfun etc..
- */
-static zval _phpglfw_callback_keycallback;
-static zval _phpglfw_callback_charcallback;
-
-void phpglfw_init_callbacks(void)
-{
-    ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-    ZVAL_UNDEF(&_phpglfw_callback_charcallback);
-}
-
-void phpglfw_shutdown_callbacks(void)
-{
-    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
-		zval_ptr_dtor(&_phpglfw_callback_keycallback);
-		ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-	}
-
-    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
-        zval_ptr_dtor(&_phpglfw_callback_charcallback);
-        ZVAL_UNDEF(&_phpglfw_callback_charcallback);
-    }
-}
-
-static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-	zval params[4];
-	zval dummy;
-
-	ZVAL_NULL(&dummy);
-
-    ZVAL_LONG(&params[0], key);
-    ZVAL_LONG(&params[1], scancode);
-    ZVAL_LONG(&params[2], action);
-    ZVAL_LONG(&params[3], mods);
-    
-	call_user_function(NULL, NULL, &_phpglfw_callback_keycallback, &dummy, 4, params);
-
-	zval_ptr_dtor(&params[0]);
-	zval_ptr_dtor(&params[1]);
-	zval_ptr_dtor(&params[2]);
-	zval_ptr_dtor(&params[3]);
-	zval_ptr_dtor(&dummy);
-}
-
-static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned int codepoint)
-{
-    zval params[1];
-    zval dummy;
-
-    ZVAL_NULL(&dummy);
-
-    ZVAL_LONG(&params[0], codepoint);
-    
-    call_user_function(NULL, NULL, &_phpglfw_callback_charcallback, &dummy, 1, params);
-
-    zval_ptr_dtor(&params[0]);
-    zval_ptr_dtor(&dummy);
-}
 
 /**
  * ----------------------------------------------------------------------------
@@ -124,6 +60,9 @@ zend_class_entry *<?php echo $ipo->getClassEntryName(); ?>;
 typedef struct _<?php echo $ipo->getObjectStructName(); ?> {
     <?php echo $ipo->getType(); ?> <?php echo $ipo->getObjectStructPointerVar(); ?>;
     zend_object std;
+<?php foreach($ipo->additionalZvals as $zval) : ?>
+    zval <?php echo $zval; ?>;
+<?php endforeach; ?>
 } <?php echo $ipo->getObjectStructName(); ?>; 
 
 <?php endforeach; ?>
@@ -212,6 +151,81 @@ void <?php echo $ipo->getObjectMinitHelperFunctionName(); ?>(void)
 }
 
 <?php endforeach; ?>
+
+    
+/**
+ * ----------------------------------------------------------------------------
+ * PHPGlfw callbacks
+ * ----------------------------------------------------------------------------
+ * callbacks like GLFWkeyfun etc..
+ */
+static zval _phpglfw_callback_keycallback;
+static zval _phpglfw_callback_charcallback;
+
+void phpglfw_init_callbacks(void)
+{
+    ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+    ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+}
+
+void phpglfw_shutdown_callbacks(void)
+{
+    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
+		zval_ptr_dtor(&_phpglfw_callback_keycallback);
+		ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+	}
+
+    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
+        zval_ptr_dtor(&_phpglfw_callback_charcallback);
+        ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+    }
+}
+
+static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+    // ensure _phpglfw_callback_keycallback is actually a function 
+    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_CALLABLE) {
+        return;
+    }
+
+	zval params[4];
+	zval dummy;
+
+	ZVAL_NULL(&dummy);
+
+    ZVAL_LONG(&params[0], key);
+    ZVAL_LONG(&params[1], scancode);
+    ZVAL_LONG(&params[2], action);
+    ZVAL_LONG(&params[3], mods);
+    
+	call_user_function(NULL, NULL, &_phpglfw_callback_keycallback, &dummy, 4, params);
+
+	zval_ptr_dtor(&params[0]);
+	zval_ptr_dtor(&params[1]);
+	zval_ptr_dtor(&params[2]);
+	zval_ptr_dtor(&params[3]);
+	zval_ptr_dtor(&dummy);
+}
+
+static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned int codepoint)
+{
+    // ensure _phpglfw_callback_charcallback is actually a function 
+    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_CALLABLE) {
+        return;
+    }
+
+    zval params[1];
+    zval dummy;
+
+    ZVAL_NULL(&dummy);
+
+    ZVAL_LONG(&params[0], codepoint);
+    
+    call_user_function(NULL, NULL, &_phpglfw_callback_charcallback, &dummy, 1, params);
+
+    zval_ptr_dtor(&params[0]);
+    zval_ptr_dtor(&dummy);
+}
 
 /**
  * ----------------------------------------------------------------------------

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -356,11 +356,11 @@ static void phpglfw_callback_windowcontentscalecallback_handler(GLFWwindow* wind
 
     phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
 
-    window_obj->windowcontentcalecallback.fci.params = params;
-    window_obj->windowcontentcalecallback.fci.param_count = 2;
-    window_obj->windowcontentcalecallback.fci.retval = &return_val;
+    window_obj->windowcontentscalecallback.fci.params = params;
+    window_obj->windowcontentscalecallback.fci.param_count = 2;
+    window_obj->windowcontentscalecallback.fci.retval = &return_val;
 
-    zend_call_function(&window_obj->windowcontentcalecallback.fci, &window_obj->windowcontentcalecallback.fci_cache);
+    zend_call_function(&window_obj->windowcontentscalecallback.fci, &window_obj->windowcontentscalecallback.fci_cache);
 
     zval_ptr_dtor(&return_val);
     efree(params);

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -60,8 +60,11 @@ zend_class_entry *<?php echo $ipo->getClassEntryName(); ?>;
 typedef struct _<?php echo $ipo->getObjectStructName(); ?> {
     <?php echo $ipo->getType(); ?> <?php echo $ipo->getObjectStructPointerVar(); ?>;
     zend_object std;
-<?php foreach($ipo->additionalZvals as $zval) : ?>
+    <?php foreach($ipo->additionalZvals as $zval) : ?>
     zval <?php echo $zval; ?>;
+<?php endforeach; ?> 
+<?php foreach($ipo->additionalCallbacks as $callback) : ?>
+    phpglfw_callback <?php echo $callback; ?>;
 <?php endforeach; ?>
 } <?php echo $ipo->getObjectStructName(); ?>; 
 

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -415,6 +415,154 @@ static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned i
     efree(params);
 }
 
+static void phpglfw_callback_charmodscallback_handler(GLFWwindow* window, unsigned int codepoint, int mods)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], codepoint);
+    ZVAL_LONG(&params[1], mods);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->charmodscallback.fci.params = params;
+    window_obj->charmodscallback.fci.param_count = 2;
+    window_obj->charmodscallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->charmodscallback.fci, &window_obj->charmodscallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_mousebuttoncallback_handler(GLFWwindow* window, int button, int action, int mods)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(3 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], button);
+    ZVAL_LONG(&params[1], action);
+    ZVAL_LONG(&params[2], mods);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->mousebuttoncallback.fci.params = params;
+    window_obj->mousebuttoncallback.fci.param_count = 3;
+    window_obj->mousebuttoncallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->mousebuttoncallback.fci, &window_obj->mousebuttoncallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_cursorposcallback_handler(GLFWwindow* window, double xpos, double ypos)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xpos);
+    ZVAL_DOUBLE(&params[1], ypos);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->cursorposcallback.fci.params = params;
+    window_obj->cursorposcallback.fci.param_count = 2;
+    window_obj->cursorposcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->cursorposcallback.fci, &window_obj->cursorposcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_cursorentercallback_handler(GLFWwindow* window, int entered)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(1 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], entered);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->cursorentercallback.fci.params = params;
+    window_obj->cursorentercallback.fci.param_count = 1;
+    window_obj->cursorentercallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->cursorentercallback.fci, &window_obj->cursorentercallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_scrollcallback_handler(GLFWwindow* window, double xoffset, double yoffset)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xoffset);
+    ZVAL_DOUBLE(&params[1], yoffset);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->scrollcallback.fci.params = params;
+    window_obj->scrollcallback.fci.param_count = 2;
+    window_obj->scrollcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->scrollcallback.fci, &window_obj->scrollcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_dropcallback_handler(GLFWwindow* window, int count, const char** paths)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], count);
+
+    array_init(&params[1]);
+    for (int i = 0; i < count; i++) {
+        add_next_index_string(&params[1], paths[i]);
+    }
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->dropcallback.fci.params = params;
+    window_obj->dropcallback.fci.param_count = 2;
+    window_obj->dropcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->dropcallback.fci, &window_obj->dropcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
 /**
  * ----------------------------------------------------------------------------
  * PHPGlfw Functions 

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -183,6 +183,188 @@ void phpglfw_shutdown_callbacks(void)
     //     ZVAL_UNDEF(&_phpglfw_callback_charcallback);
     // }
 }
+static void phpglfw_callback_windowposcallback_handler(GLFWwindow* window, int xpos, int ypos)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], xpos);
+    ZVAL_LONG(&params[1], ypos);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowposcallback.fci.params = params;
+    window_obj->windowposcallback.fci.param_count = 2;
+    window_obj->windowposcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowposcallback.fci, &window_obj->windowposcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowsizecallback_handler(GLFWwindow* window, int width, int height)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], width);
+    ZVAL_LONG(&params[1], height);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowsizecallback.fci.params = params;
+    window_obj->windowsizecallback.fci.param_count = 2;
+    window_obj->windowsizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowsizecallback.fci, &window_obj->windowsizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowclosecallback_handler(GLFWwindow* window)
+{
+    zval return_val;
+
+    ZVAL_NULL(&return_val);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowclosecallback.fci.param_count = 0;
+    window_obj->windowclosecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowclosecallback.fci, &window_obj->windowclosecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+}
+
+static void phpglfw_callback_windowrefreshcallback_handler(GLFWwindow* window)
+{
+    zval return_val;
+
+    ZVAL_NULL(&return_val);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowrefreshcallback.fci.param_count = 0;
+    window_obj->windowrefreshcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowrefreshcallback.fci, &window_obj->windowrefreshcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+}
+
+static void phpglfw_callback_windowfocuscallback_handler(GLFWwindow* window, int focused)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], focused);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowfocuscallback.fci.params = params;
+    window_obj->windowfocuscallback.fci.param_count = 1;
+    window_obj->windowfocuscallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowfocuscallback.fci, &window_obj->windowfocuscallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowiconifycallback_handler(GLFWwindow* window, int iconified)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], iconified);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowiconifycallback.fci.params = params;
+    window_obj->windowiconifycallback.fci.param_count = 1;
+    window_obj->windowiconifycallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowiconifycallback.fci, &window_obj->windowiconifycallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowmaximizecallback_handler(GLFWwindow* window, int maximized)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], maximized);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowmaximizecallback.fci.params = params;
+    window_obj->windowmaximizecallback.fci.param_count = 1;
+    window_obj->windowmaximizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowmaximizecallback.fci, &window_obj->windowmaximizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowframebuffersizecallback_handler(GLFWwindow* window, int width, int height)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], width);
+    ZVAL_LONG(&params[1], height);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowframebuffersizecallback.fci.params = params;
+    window_obj->windowframebuffersizecallback.fci.param_count = 2;
+    window_obj->windowframebuffersizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowframebuffersizecallback.fci, &window_obj->windowframebuffersizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowcontentscalecallback_handler(GLFWwindow* window, float xscale, float yscale)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xscale);
+    ZVAL_DOUBLE(&params[1], yscale);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowcontentcalecallback.fci.params = params;
+    window_obj->windowcontentcalecallback.fci.param_count = 2;
+    window_obj->windowcontentcalecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowcontentcalecallback.fci, &window_obj->windowcontentcalecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
 
 static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
 {

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -162,72 +162,75 @@ void <?php echo $ipo->getObjectMinitHelperFunctionName(); ?>(void)
  * ----------------------------------------------------------------------------
  * callbacks like GLFWkeyfun etc..
  */
-static zval _phpglfw_callback_keycallback;
-static zval _phpglfw_callback_charcallback;
+// static zval _phpglfw_callback_keycallback;
+// static zval _phpglfw_callback_charcallback;
 
 void phpglfw_init_callbacks(void)
 {
-    ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-    ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+//     ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+//     ZVAL_UNDEF(&_phpglfw_callback_charcallback);
 }
 
 void phpglfw_shutdown_callbacks(void)
 {
-    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
-		zval_ptr_dtor(&_phpglfw_callback_keycallback);
-		ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-	}
+    // if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
+	// 	zval_ptr_dtor(&_phpglfw_callback_keycallback);
+	// 	ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+	// }
 
-    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
-        zval_ptr_dtor(&_phpglfw_callback_charcallback);
-        ZVAL_UNDEF(&_phpglfw_callback_charcallback);
-    }
+    // if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
+    //     zval_ptr_dtor(&_phpglfw_callback_charcallback);
+    //     ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+    // }
 }
 
 static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
-    // ensure _phpglfw_callback_keycallback is actually a function 
-    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_CALLABLE) {
-        return;
-    }
+    // update args of the callback function entry
+	zval return_val;
+	zval *params = emalloc(4 * sizeof(zval));
 
-	zval params[4];
-	zval dummy;
-
-	ZVAL_NULL(&dummy);
+	ZVAL_NULL(&return_val);
 
     ZVAL_LONG(&params[0], key);
     ZVAL_LONG(&params[1], scancode);
     ZVAL_LONG(&params[2], action);
     ZVAL_LONG(&params[3], mods);
-    
-	call_user_function(NULL, NULL, &_phpglfw_callback_keycallback, &dummy, 4, params);
 
-	zval_ptr_dtor(&params[0]);
-	zval_ptr_dtor(&params[1]);
-	zval_ptr_dtor(&params[2]);
-	zval_ptr_dtor(&params[3]);
-	zval_ptr_dtor(&dummy);
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->keycallback.fci.params = params;
+    window_obj->keycallback.fci.param_count = 4;
+    window_obj->keycallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->keycallback.fci, &window_obj->keycallback.fci_cache);
+
+	zval_ptr_dtor(&return_val);
+    efree(params);
 }
 
 static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned int codepoint)
 {
-    // ensure _phpglfw_callback_charcallback is actually a function 
-    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_CALLABLE) {
-        return;
-    }
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(1 * sizeof(zval));
 
-    zval params[1];
-    zval dummy;
-
-    ZVAL_NULL(&dummy);
+    ZVAL_NULL(&return_val);
 
     ZVAL_LONG(&params[0], codepoint);
-    
-    call_user_function(NULL, NULL, &_phpglfw_callback_charcallback, &dummy, 1, params);
 
-    zval_ptr_dtor(&params[0]);
-    zval_ptr_dtor(&dummy);
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->charcallback.fci.params = params;
+    window_obj->charcallback.fci.param_count = 1;
+    window_obj->charcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->charcallback.fci, &window_obj->charcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
 }
 
 /**

--- a/generator/templates/phpglfw_functions.h.php
+++ b/generator/templates/phpglfw_functions.h.php
@@ -37,8 +37,13 @@ void <?php echo $ipo->getObjectMinitHelperFunctionName(); ?>(void);
 <?php endforeach; ?>
 
 /**
- * Global callback handling
+ * callback handling
  */
+typedef struct {
+    zend_fcall_info fci;
+    zend_fcall_info_cache fci_cache;
+} phpglfw_callback;
+
 void phpglfw_init_callbacks(void);
 void phpglfw_shutdown_callbacks(void);
 

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -2459,6 +2459,12 @@ namespace {
     function glfwSetCursor(GLFWwindow $window, GLFWcursor $cursor) : void {};
     function glfwSetKeyCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwSetCharCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetCharModsCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetMouseButtonCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetCursorPosCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetCursorEnterCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetScrollCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetDropCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwJoystickPresent(int $jid) : int {};
     function glfwGetJoystickName(int $jid) : string {};
     function glfwGetJoystickGUID(int $jid) : string {};

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -2432,6 +2432,9 @@ namespace {
     function glfwSetWindowMonitor(GLFWwindow $window, GLFWmonitor $monitor, int $xpos, int $ypos, int $width, int $height, int $refreshRate) : void {};
     function glfwGetWindowAttrib(GLFWwindow $window, int $attrib) : int {};
     function glfwSetWindowAttrib(GLFWwindow $window, int $attrib, int $value) : void {};
+    function glfwSetWindowPosCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowSizeCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowCloseCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwPollEvents() : void {};
     function glfwWaitEvents() : void {};
     function glfwWaitEventsTimeout(float $timeout) : void {};

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -2199,13 +2199,8 @@ namespace {
     function glGetActiveUniformBlockiv(int $program, int $uniformBlockIndex, int $pname, int &$params) : void {};
     function glUniformBlockBinding(int $program, int $uniformBlockIndex, int $uniformBlockBinding) : void {};
     function glProvokingVertex(int $mode) : void {};
-    function glFenceSync(int $condition, int $flags) : int {};
     function glIsSync(int $sync) : bool {};
-    function glDeleteSync(int $sync) : void {};
-    function glClientWaitSync(int $sync, int $flags, int $timeout) : int {};
-    function glWaitSync(int $sync, int $flags, int $timeout) : void {};
     function glGetInteger64v(int $pname, int &$data) : void {};
-    function glGetSynciv(int $sync, int $pname, int $count, int &$length, int &$values) : void {};
     function glGetInteger64i_v(int $target, int $index, int &$data) : void {};
     function glGetBufferParameteri64v(int $target, int $pname, int &$params) : void {};
     function glFramebufferTexture(int $target, int $attachment, int $texture, int $level) : void {};

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -2435,6 +2435,12 @@ namespace {
     function glfwSetWindowPosCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwSetWindowSizeCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwSetWindowCloseCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowRefreshCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowFocusCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowIconifyCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowMaximizeCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetFramebufferSizeCallback(GLFWwindow $window, callable $callback) : void {};
+    function glfwSetWindowContentScaleCallback(GLFWwindow $window, callable $callback) : void {};
     function glfwPollEvents() : void {};
     function glfwWaitEvents() : void {};
     function glfwWaitEventsTimeout(float $timeout) : void {};

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e7c3b1799c3eb7c38176c6421a286cb919b3b1a9 */
+ * Stub hash: 68d65e39acb5487492570805b5b17a803b609cab */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -2117,6 +2117,18 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_glfwSetCharCallback arginfo_glfwSetWindowPosCallback
 
+#define arginfo_glfwSetCharModsCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetMouseButtonCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetCursorPosCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetCursorEnterCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetScrollCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetDropCallback arginfo_glfwSetWindowPosCallback
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwJoystickPresent, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, jid, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -3122,6 +3134,12 @@ ZEND_FUNCTION(glfwDestroyCursor);
 ZEND_FUNCTION(glfwSetCursor);
 ZEND_FUNCTION(glfwSetKeyCallback);
 ZEND_FUNCTION(glfwSetCharCallback);
+ZEND_FUNCTION(glfwSetCharModsCallback);
+ZEND_FUNCTION(glfwSetMouseButtonCallback);
+ZEND_FUNCTION(glfwSetCursorPosCallback);
+ZEND_FUNCTION(glfwSetCursorEnterCallback);
+ZEND_FUNCTION(glfwSetScrollCallback);
+ZEND_FUNCTION(glfwSetDropCallback);
 ZEND_FUNCTION(glfwJoystickPresent);
 ZEND_FUNCTION(glfwGetJoystickName);
 ZEND_FUNCTION(glfwGetJoystickGUID);
@@ -3811,6 +3829,12 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(glfwSetCursor, arginfo_glfwSetCursor)
 	ZEND_FE(glfwSetKeyCallback, arginfo_glfwSetKeyCallback)
 	ZEND_FE(glfwSetCharCallback, arginfo_glfwSetCharCallback)
+	ZEND_FE(glfwSetCharModsCallback, arginfo_glfwSetCharModsCallback)
+	ZEND_FE(glfwSetMouseButtonCallback, arginfo_glfwSetMouseButtonCallback)
+	ZEND_FE(glfwSetCursorPosCallback, arginfo_glfwSetCursorPosCallback)
+	ZEND_FE(glfwSetCursorEnterCallback, arginfo_glfwSetCursorEnterCallback)
+	ZEND_FE(glfwSetScrollCallback, arginfo_glfwSetScrollCallback)
+	ZEND_FE(glfwSetDropCallback, arginfo_glfwSetDropCallback)
 	ZEND_FE(glfwJoystickPresent, arginfo_glfwJoystickPresent)
 	ZEND_FE(glfwGetJoystickName, arginfo_glfwGetJoystickName)
 	ZEND_FE(glfwGetJoystickGUID, arginfo_glfwGetJoystickGUID)

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 43bbb3beb1676eabab34980af88453cc39b6b93c */
+ * Stub hash: a3f211321ec23398438df9af6bbfbb4bb9516485 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -1113,42 +1113,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_glProvokingVertex arginfo_glCullFace
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glFenceSync, 0, 2, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, condition, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glIsSync, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, sync, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glDeleteSync, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, sync, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glClientWaitSync, 0, 3, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, sync, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glWaitSync, 0, 3, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, sync, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glGetInteger64v, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, pname, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(1, data, IS_LONG, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glGetSynciv, 0, 5, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, sync, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, pname, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, count, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(1, length, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(1, values, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glGetInteger64i_v, 0, 3, IS_VOID, 0)
@@ -2873,13 +2844,8 @@ ZEND_FUNCTION(glGetUniformBlockIndex);
 ZEND_FUNCTION(glGetActiveUniformBlockiv);
 ZEND_FUNCTION(glUniformBlockBinding);
 ZEND_FUNCTION(glProvokingVertex);
-ZEND_FUNCTION(glFenceSync);
 ZEND_FUNCTION(glIsSync);
-ZEND_FUNCTION(glDeleteSync);
-ZEND_FUNCTION(glClientWaitSync);
-ZEND_FUNCTION(glWaitSync);
 ZEND_FUNCTION(glGetInteger64v);
-ZEND_FUNCTION(glGetSynciv);
 ZEND_FUNCTION(glGetInteger64i_v);
 ZEND_FUNCTION(glGetBufferParameteri64v);
 ZEND_FUNCTION(glFramebufferTexture);
@@ -3558,13 +3524,8 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(glGetActiveUniformBlockiv, arginfo_glGetActiveUniformBlockiv)
 	ZEND_FE(glUniformBlockBinding, arginfo_glUniformBlockBinding)
 	ZEND_FE(glProvokingVertex, arginfo_glProvokingVertex)
-	ZEND_FE(glFenceSync, arginfo_glFenceSync)
 	ZEND_FE(glIsSync, arginfo_glIsSync)
-	ZEND_FE(glDeleteSync, arginfo_glDeleteSync)
-	ZEND_FE(glClientWaitSync, arginfo_glClientWaitSync)
-	ZEND_FE(glWaitSync, arginfo_glWaitSync)
 	ZEND_FE(glGetInteger64v, arginfo_glGetInteger64v)
-	ZEND_FE(glGetSynciv, arginfo_glGetSynciv)
 	ZEND_FE(glGetInteger64i_v, arginfo_glGetInteger64i_v)
 	ZEND_FE(glGetBufferParameteri64v, arginfo_glGetBufferParameteri64v)
 	ZEND_FE(glFramebufferTexture, arginfo_glFramebufferTexture)

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 09794d164fd8feecb784910e0b8944477e366f8c */
+ * Stub hash: e7c3b1799c3eb7c38176c6421a286cb919b3b1a9 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -2034,6 +2034,18 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_glfwSetWindowCloseCallback arginfo_glfwSetWindowPosCallback
 
+#define arginfo_glfwSetWindowRefreshCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetWindowFocusCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetWindowIconifyCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetWindowMaximizeCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetFramebufferSizeCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetWindowContentScaleCallback arginfo_glfwSetWindowPosCallback
+
 #define arginfo_glfwPollEvents arginfo_glFinish
 
 #define arginfo_glfwWaitEvents arginfo_glFinish
@@ -3086,6 +3098,12 @@ ZEND_FUNCTION(glfwSetWindowAttrib);
 ZEND_FUNCTION(glfwSetWindowPosCallback);
 ZEND_FUNCTION(glfwSetWindowSizeCallback);
 ZEND_FUNCTION(glfwSetWindowCloseCallback);
+ZEND_FUNCTION(glfwSetWindowRefreshCallback);
+ZEND_FUNCTION(glfwSetWindowFocusCallback);
+ZEND_FUNCTION(glfwSetWindowIconifyCallback);
+ZEND_FUNCTION(glfwSetWindowMaximizeCallback);
+ZEND_FUNCTION(glfwSetFramebufferSizeCallback);
+ZEND_FUNCTION(glfwSetWindowContentScaleCallback);
 ZEND_FUNCTION(glfwPollEvents);
 ZEND_FUNCTION(glfwWaitEvents);
 ZEND_FUNCTION(glfwWaitEventsTimeout);
@@ -3769,6 +3787,12 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(glfwSetWindowPosCallback, arginfo_glfwSetWindowPosCallback)
 	ZEND_FE(glfwSetWindowSizeCallback, arginfo_glfwSetWindowSizeCallback)
 	ZEND_FE(glfwSetWindowCloseCallback, arginfo_glfwSetWindowCloseCallback)
+	ZEND_FE(glfwSetWindowRefreshCallback, arginfo_glfwSetWindowRefreshCallback)
+	ZEND_FE(glfwSetWindowFocusCallback, arginfo_glfwSetWindowFocusCallback)
+	ZEND_FE(glfwSetWindowIconifyCallback, arginfo_glfwSetWindowIconifyCallback)
+	ZEND_FE(glfwSetWindowMaximizeCallback, arginfo_glfwSetWindowMaximizeCallback)
+	ZEND_FE(glfwSetFramebufferSizeCallback, arginfo_glfwSetFramebufferSizeCallback)
+	ZEND_FE(glfwSetWindowContentScaleCallback, arginfo_glfwSetWindowContentScaleCallback)
 	ZEND_FE(glfwPollEvents, arginfo_glfwPollEvents)
 	ZEND_FE(glfwWaitEvents, arginfo_glfwWaitEvents)
 	ZEND_FE(glfwWaitEventsTimeout, arginfo_glfwWaitEventsTimeout)

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a3f211321ec23398438df9af6bbfbb4bb9516485 */
+ * Stub hash: 09794d164fd8feecb784910e0b8944477e366f8c */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -2025,6 +2025,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwSetWindowAttrib, 0, 3, IS_VO
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwSetWindowPosCallback, 0, 2, IS_VOID, 0)
+	ZEND_ARG_OBJ_INFO(0, window, GLFWwindow, 0)
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_glfwSetWindowSizeCallback arginfo_glfwSetWindowPosCallback
+
+#define arginfo_glfwSetWindowCloseCallback arginfo_glfwSetWindowPosCallback
+
 #define arginfo_glfwPollEvents arginfo_glFinish
 
 #define arginfo_glfwWaitEvents arginfo_glFinish
@@ -2092,12 +2101,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwSetCursor, 0, 2, IS_VOID, 0)
 	ZEND_ARG_OBJ_INFO(0, cursor, GLFWcursor, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwSetKeyCallback, 0, 2, IS_VOID, 0)
-	ZEND_ARG_OBJ_INFO(0, window, GLFWwindow, 0)
-	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_glfwSetKeyCallback arginfo_glfwSetWindowPosCallback
 
-#define arginfo_glfwSetCharCallback arginfo_glfwSetKeyCallback
+#define arginfo_glfwSetCharCallback arginfo_glfwSetWindowPosCallback
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glfwJoystickPresent, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, jid, IS_LONG, 0)
@@ -3077,6 +3083,9 @@ ZEND_FUNCTION(glfwGetWindowMonitor);
 ZEND_FUNCTION(glfwSetWindowMonitor);
 ZEND_FUNCTION(glfwGetWindowAttrib);
 ZEND_FUNCTION(glfwSetWindowAttrib);
+ZEND_FUNCTION(glfwSetWindowPosCallback);
+ZEND_FUNCTION(glfwSetWindowSizeCallback);
+ZEND_FUNCTION(glfwSetWindowCloseCallback);
 ZEND_FUNCTION(glfwPollEvents);
 ZEND_FUNCTION(glfwWaitEvents);
 ZEND_FUNCTION(glfwWaitEventsTimeout);
@@ -3757,6 +3766,9 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(glfwSetWindowMonitor, arginfo_glfwSetWindowMonitor)
 	ZEND_FE(glfwGetWindowAttrib, arginfo_glfwGetWindowAttrib)
 	ZEND_FE(glfwSetWindowAttrib, arginfo_glfwSetWindowAttrib)
+	ZEND_FE(glfwSetWindowPosCallback, arginfo_glfwSetWindowPosCallback)
+	ZEND_FE(glfwSetWindowSizeCallback, arginfo_glfwSetWindowSizeCallback)
+	ZEND_FE(glfwSetWindowCloseCallback, arginfo_glfwSetWindowCloseCallback)
 	ZEND_FE(glfwPollEvents, arginfo_glfwPollEvents)
 	ZEND_FE(glfwWaitEvents, arginfo_glfwWaitEvents)
 	ZEND_FE(glfwWaitEventsTimeout, arginfo_glfwWaitEventsTimeout)

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -68,7 +68,7 @@ typedef struct _phpglfw_glfwwindow_object {
     phpglfw_callback windowiconifycallback;
     phpglfw_callback windowmaximizecallback;
     phpglfw_callback windowframebuffersizecallback;
-    phpglfw_callback windowcontentcalecallback;
+    phpglfw_callback windowcontentscalecallback;
     phpglfw_callback keycallback;
     phpglfw_callback charcallback;
     phpglfw_callback charmodscallback;
@@ -540,11 +540,11 @@ static void phpglfw_callback_windowcontentscalecallback_handler(GLFWwindow* wind
 
     phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
 
-    window_obj->windowcontentcalecallback.fci.params = params;
-    window_obj->windowcontentcalecallback.fci.param_count = 2;
-    window_obj->windowcontentcalecallback.fci.retval = &return_val;
+    window_obj->windowcontentscalecallback.fci.params = params;
+    window_obj->windowcontentscalecallback.fci.param_count = 2;
+    window_obj->windowcontentscalecallback.fci.retval = &return_val;
 
-    zend_call_function(&window_obj->windowcontentcalecallback.fci, &window_obj->windowcontentcalecallback.fci_cache);
+    zend_call_function(&window_obj->windowcontentscalecallback.fci, &window_obj->windowcontentscalecallback.fci_cache);
 
     zval_ptr_dtor(&return_val);
     efree(params);
@@ -10885,6 +10885,132 @@ PHP_FUNCTION(glfwSetWindowCloseCallback)
     memcpy((void*)&obj_ptr->windowclosecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
     memcpy((void*)&obj_ptr->windowclosecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
     glfwSetWindowCloseCallback(obj_ptr->glfwwindow, phpglfw_callback_windowclosecallback_handler);
+} 
+
+/**
+ * glfwSetWindowRefreshCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowRefreshCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowrefreshcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowrefreshcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowRefreshCallback(obj_ptr->glfwwindow, phpglfw_callback_windowrefreshcallback_handler);
+} 
+
+/**
+ * glfwSetWindowFocusCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowFocusCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowfocuscallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowfocuscallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowFocusCallback(obj_ptr->glfwwindow, phpglfw_callback_windowfocuscallback_handler);
+} 
+
+/**
+ * glfwSetWindowIconifyCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowIconifyCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowiconifycallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowiconifycallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowIconifyCallback(obj_ptr->glfwwindow, phpglfw_callback_windowiconifycallback_handler);
+} 
+
+/**
+ * glfwSetWindowMaximizeCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowMaximizeCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowmaximizecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowmaximizecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowMaximizeCallback(obj_ptr->glfwwindow, phpglfw_callback_windowmaximizecallback_handler);
+} 
+
+/**
+ * glfwSetFramebufferSizeCallback
+ */ 
+PHP_FUNCTION(glfwSetFramebufferSizeCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowframebuffersizecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowframebuffersizecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetFramebufferSizeCallback(obj_ptr->glfwwindow, phpglfw_callback_windowframebuffersizecallback_handler);
+} 
+
+/**
+ * glfwSetWindowContentScaleCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowContentScaleCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowcontentscalecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowcontentscalecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowContentScaleCallback(obj_ptr->glfwwindow, phpglfw_callback_windowcontentscalecallback_handler);
 } 
 
 /**

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -599,6 +599,154 @@ static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned i
     efree(params);
 }
 
+static void phpglfw_callback_charmodscallback_handler(GLFWwindow* window, unsigned int codepoint, int mods)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], codepoint);
+    ZVAL_LONG(&params[1], mods);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->charmodscallback.fci.params = params;
+    window_obj->charmodscallback.fci.param_count = 2;
+    window_obj->charmodscallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->charmodscallback.fci, &window_obj->charmodscallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_mousebuttoncallback_handler(GLFWwindow* window, int button, int action, int mods)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(3 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], button);
+    ZVAL_LONG(&params[1], action);
+    ZVAL_LONG(&params[2], mods);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->mousebuttoncallback.fci.params = params;
+    window_obj->mousebuttoncallback.fci.param_count = 3;
+    window_obj->mousebuttoncallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->mousebuttoncallback.fci, &window_obj->mousebuttoncallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_cursorposcallback_handler(GLFWwindow* window, double xpos, double ypos)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xpos);
+    ZVAL_DOUBLE(&params[1], ypos);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->cursorposcallback.fci.params = params;
+    window_obj->cursorposcallback.fci.param_count = 2;
+    window_obj->cursorposcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->cursorposcallback.fci, &window_obj->cursorposcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_cursorentercallback_handler(GLFWwindow* window, int entered)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(1 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], entered);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->cursorentercallback.fci.params = params;
+    window_obj->cursorentercallback.fci.param_count = 1;
+    window_obj->cursorentercallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->cursorentercallback.fci, &window_obj->cursorentercallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_scrollcallback_handler(GLFWwindow* window, double xoffset, double yoffset)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xoffset);
+    ZVAL_DOUBLE(&params[1], yoffset);
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->scrollcallback.fci.params = params;
+    window_obj->scrollcallback.fci.param_count = 2;
+    window_obj->scrollcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->scrollcallback.fci, &window_obj->scrollcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_dropcallback_handler(GLFWwindow* window, int count, const char** paths)
+{
+    // update args of the callback function entry
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], count);
+
+    array_init(&params[1]);
+    for (int i = 0; i < count; i++) {
+        add_next_index_string(&params[1], paths[i]);
+    }
+
+    // load the internal obj from the user pointer
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->dropcallback.fci.params = params;
+    window_obj->dropcallback.fci.param_count = 2;
+    window_obj->dropcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->dropcallback.fci, &window_obj->dropcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
 /**
  * ----------------------------------------------------------------------------
  * PHPGlfw Functions 
@@ -11267,6 +11415,132 @@ PHP_FUNCTION(glfwSetCharCallback)
     memcpy((void*)&obj_ptr->charcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
     memcpy((void*)&obj_ptr->charcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
     glfwSetCharCallback(obj_ptr->glfwwindow, phpglfw_callback_charcallback_handler);
+} 
+
+/**
+ * glfwSetCharModsCallback
+ */ 
+PHP_FUNCTION(glfwSetCharModsCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->charmodscallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->charmodscallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetCharModsCallback(obj_ptr->glfwwindow, phpglfw_callback_charmodscallback_handler);
+} 
+
+/**
+ * glfwSetMouseButtonCallback
+ */ 
+PHP_FUNCTION(glfwSetMouseButtonCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->mousebuttoncallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->mousebuttoncallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetMouseButtonCallback(obj_ptr->glfwwindow, phpglfw_callback_mousebuttoncallback_handler);
+} 
+
+/**
+ * glfwSetCursorPosCallback
+ */ 
+PHP_FUNCTION(glfwSetCursorPosCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->cursorposcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->cursorposcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetCursorPosCallback(obj_ptr->glfwwindow, phpglfw_callback_cursorposcallback_handler);
+} 
+
+/**
+ * glfwSetCursorEnterCallback
+ */ 
+PHP_FUNCTION(glfwSetCursorEnterCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->cursorentercallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->cursorentercallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetCursorEnterCallback(obj_ptr->glfwwindow, phpglfw_callback_cursorentercallback_handler);
+} 
+
+/**
+ * glfwSetScrollCallback
+ */ 
+PHP_FUNCTION(glfwSetScrollCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->scrollcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->scrollcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetScrollCallback(obj_ptr->glfwwindow, phpglfw_callback_scrollcallback_handler);
+} 
+
+/**
+ * glfwSetDropCallback
+ */ 
+PHP_FUNCTION(glfwSetDropCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->dropcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->dropcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetDropCallback(obj_ptr->glfwwindow, phpglfw_callback_dropcallback_handler);
 } 
 
 /**

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -30,70 +30,6 @@
 #include "phpglfw_buffer.h"
 #include "phpglfw_math.h"
 #include <zend_API.h>
-    
-/**
- * ----------------------------------------------------------------------------
- * PHPGlfw Global callbacks
- * ----------------------------------------------------------------------------
- * Global callbacks like GLFWkeyfun etc..
- */
-static zval _phpglfw_callback_keycallback;
-static zval _phpglfw_callback_charcallback;
-
-void phpglfw_init_callbacks(void)
-{
-    ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-    ZVAL_UNDEF(&_phpglfw_callback_charcallback);
-}
-
-void phpglfw_shutdown_callbacks(void)
-{
-    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
-		zval_ptr_dtor(&_phpglfw_callback_keycallback);
-		ZVAL_UNDEF(&_phpglfw_callback_keycallback);
-	}
-
-    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
-        zval_ptr_dtor(&_phpglfw_callback_charcallback);
-        ZVAL_UNDEF(&_phpglfw_callback_charcallback);
-    }
-}
-
-static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-	zval params[4];
-	zval dummy;
-
-	ZVAL_NULL(&dummy);
-
-    ZVAL_LONG(&params[0], key);
-    ZVAL_LONG(&params[1], scancode);
-    ZVAL_LONG(&params[2], action);
-    ZVAL_LONG(&params[3], mods);
-    
-	call_user_function(NULL, NULL, &_phpglfw_callback_keycallback, &dummy, 4, params);
-
-	zval_ptr_dtor(&params[0]);
-	zval_ptr_dtor(&params[1]);
-	zval_ptr_dtor(&params[2]);
-	zval_ptr_dtor(&params[3]);
-	zval_ptr_dtor(&dummy);
-}
-
-static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned int codepoint)
-{
-    zval params[1];
-    zval dummy;
-
-    ZVAL_NULL(&dummy);
-
-    ZVAL_LONG(&params[0], codepoint);
-    
-    call_user_function(NULL, NULL, &_phpglfw_callback_charcallback, &dummy, 1, params);
-
-    zval_ptr_dtor(&params[0]);
-    zval_ptr_dtor(&dummy);
-}
 
 /**
  * ----------------------------------------------------------------------------
@@ -123,6 +59,23 @@ zend_class_entry *phpglfw_glfwcursor_ce;
 typedef struct _phpglfw_glfwwindow_object {
     GLFWwindow* glfwwindow;
     zend_object std;
+    zval poscallback;
+    zval sizecallback;
+    zval closecallback;
+    zval refreshcallback;
+    zval focuscallback;
+    zval iconifycallback;
+    zval maximizecallback;
+    zval framebuffersizecallback;
+    zval contentcalecallback;
+    zval keycallback;
+    zval charcallback;
+    zval charmodscallback;
+    zval mousebuttoncallback;
+    zval cursorposcallback;
+    zval cursorentercallback;
+    zval scrollcallback;
+    zval dropcallback;
 } phpglfw_glfwwindow_object; 
 
 typedef struct _phpglfw_glfwmonitor_object {
@@ -382,6 +335,81 @@ GLFWcursor* phpglfw_glfwcursorptr_from_zval_ptr(zval* zp)
     return phpglfw_glfwcursor_objectptr_from_zobj_p(Z_OBJ_P(zp))->glfwcursor;
 }
 
+
+    
+/**
+ * ----------------------------------------------------------------------------
+ * PHPGlfw callbacks
+ * ----------------------------------------------------------------------------
+ * callbacks like GLFWkeyfun etc..
+ */
+static zval _phpglfw_callback_keycallback;
+static zval _phpglfw_callback_charcallback;
+
+void phpglfw_init_callbacks(void)
+{
+    ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+    ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+}
+
+void phpglfw_shutdown_callbacks(void)
+{
+    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
+		zval_ptr_dtor(&_phpglfw_callback_keycallback);
+		ZVAL_UNDEF(&_phpglfw_callback_keycallback);
+	}
+
+    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_UNDEF) {
+        zval_ptr_dtor(&_phpglfw_callback_charcallback);
+        ZVAL_UNDEF(&_phpglfw_callback_charcallback);
+    }
+}
+
+static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+    // ensure _phpglfw_callback_keycallback is actually a function 
+    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_CALLABLE) {
+        return;
+    }
+
+	zval params[4];
+	zval dummy;
+
+	ZVAL_NULL(&dummy);
+
+    ZVAL_LONG(&params[0], key);
+    ZVAL_LONG(&params[1], scancode);
+    ZVAL_LONG(&params[2], action);
+    ZVAL_LONG(&params[3], mods);
+    
+	call_user_function(NULL, NULL, &_phpglfw_callback_keycallback, &dummy, 4, params);
+
+	zval_ptr_dtor(&params[0]);
+	zval_ptr_dtor(&params[1]);
+	zval_ptr_dtor(&params[2]);
+	zval_ptr_dtor(&params[3]);
+	zval_ptr_dtor(&dummy);
+}
+
+static void phpglfw_callback_charcallback_handler(GLFWwindow* window, unsigned int codepoint)
+{
+    // ensure _phpglfw_callback_charcallback is actually a function 
+    if (Z_TYPE(_phpglfw_callback_charcallback) != IS_CALLABLE) {
+        return;
+    }
+
+    zval params[1];
+    zval dummy;
+
+    ZVAL_NULL(&dummy);
+
+    ZVAL_LONG(&params[0], codepoint);
+    
+    call_user_function(NULL, NULL, &_phpglfw_callback_charcallback, &dummy, 1, params);
+
+    zval_ptr_dtor(&params[0]);
+    zval_ptr_dtor(&dummy);
+}
 
 /**
  * ----------------------------------------------------------------------------
@@ -5698,19 +5726,6 @@ PHP_FUNCTION(glProvokingVertex)
 } 
 
 /**
- * glFenceSync
- */ 
-PHP_FUNCTION(glFenceSync)
-{
-    zend_long condition;
-    zend_long flags;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() , "ll", &condition, &flags) == FAILURE) {
-        return;
-    }
-    RETURN_LONG(glFenceSync(condition, flags));
-} 
-
-/**
  * glIsSync
  */ 
 PHP_FUNCTION(glIsSync)
@@ -5720,46 +5735,6 @@ PHP_FUNCTION(glIsSync)
         return;
     }
     RETURN_BOOL(glIsSync(sync));
-} 
-
-/**
- * glDeleteSync
- */ 
-PHP_FUNCTION(glDeleteSync)
-{
-    zend_long sync;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() , "l", &sync) == FAILURE) {
-        return;
-    }
-    glDeleteSync(sync);
-} 
-
-/**
- * glClientWaitSync
- */ 
-PHP_FUNCTION(glClientWaitSync)
-{
-    zend_long sync;
-    zend_long flags;
-    zend_long timeout;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() , "lll", &sync, &flags, &timeout) == FAILURE) {
-        return;
-    }
-    RETURN_LONG(glClientWaitSync(sync, flags, timeout));
-} 
-
-/**
- * glWaitSync
- */ 
-PHP_FUNCTION(glWaitSync)
-{
-    zend_long sync;
-    zend_long flags;
-    zend_long timeout;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() , "lll", &sync, &flags, &timeout) == FAILURE) {
-        return;
-    }
-    glWaitSync(sync, flags, timeout);
 } 
 
 /**
@@ -5777,30 +5752,6 @@ PHP_FUNCTION(glGetInteger64v)
     convert_to_long(data_zval);
     glGetInteger64v(pname, &data_tmp);
     ZVAL_LONG(data_zval, data_tmp);
-} 
-
-/**
- * glGetSynciv
- */ 
-PHP_FUNCTION(glGetSynciv)
-{
-    zend_long sync;
-    zend_long pname;
-    zend_long count;
-    zval *length_zval;
-    GLsizei length_tmp;
-    zval *values_zval;
-    GLint values_tmp;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() , "lllzz", &sync, &pname, &count, &length_zval, &values_zval) == FAILURE) {
-        return;
-    }
-    ZVAL_DEREF(length_zval);
-    convert_to_long(length_zval);
-    ZVAL_DEREF(values_zval);
-    convert_to_long(values_zval);
-    glGetSynciv(sync, pname, count, &length_tmp, &values_tmp);
-    ZVAL_LONG(length_zval, length_tmp);
-    ZVAL_LONG(values_zval, values_tmp);
 } 
 
 /**
@@ -10252,6 +10203,10 @@ PHP_FUNCTION(glfwCreateWindow)
     }
     GLFWwindow* glfwwindow = glfwCreateWindow(width, height, title, monitor, share);
     phpglfw_glfwwindow_ptr_assign_to_zval_p(return_value, glfwwindow);
+    // ensure user pointer is our internal window object
+    zval *windowzval_userptr = NULL;
+    ZVAL_COPY(windowzval_userptr, return_value);
+    glfwSetWindowUserPointer(glfwwindow, windowzval_userptr);
 } 
 
 /**
@@ -10901,11 +10856,17 @@ PHP_FUNCTION(glfwSetKeyCallback)
     if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
         RETURN_THROWS();
     }
-    if (Z_TYPE(_phpglfw_callback_keycallback) != IS_UNDEF) {
-        zval_ptr_dtor(&_phpglfw_callback_keycallback);
+
+    phpglfw_glfwwindow_object *window = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+
+    // release old callback
+    if (Z_TYPE(window->keycallback) == IS_CALLABLE) {
+        zval_ptr_dtor(&window->keycallback);
     }
-    GLFWwindow* window = phpglfw_glfwwindowptr_from_zval_ptr(window_zval);
+
     ZVAL_COPY(&_phpglfw_callback_keycallback, &fci.function_name);
+
+    GLFWwindow* window = phpglfw_glfwwindowptr_from_zval_ptr(window_zval);
     glfwSetKeyCallback(window, phpglfw_callback_keycallback_handler);
 } 
 

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -60,15 +60,15 @@ typedef struct _phpglfw_glfwwindow_object {
     GLFWwindow* glfwwindow;
     zend_object std;
      
-    phpglfw_callback poscallback;
-    phpglfw_callback sizecallback;
-    phpglfw_callback closecallback;
-    phpglfw_callback refreshcallback;
-    phpglfw_callback focuscallback;
-    phpglfw_callback iconifycallback;
-    phpglfw_callback maximizecallback;
-    phpglfw_callback framebuffersizecallback;
-    phpglfw_callback contentcalecallback;
+    phpglfw_callback windowposcallback;
+    phpglfw_callback windowsizecallback;
+    phpglfw_callback windowclosecallback;
+    phpglfw_callback windowrefreshcallback;
+    phpglfw_callback windowfocuscallback;
+    phpglfw_callback windowiconifycallback;
+    phpglfw_callback windowmaximizecallback;
+    phpglfw_callback windowframebuffersizecallback;
+    phpglfw_callback windowcontentcalecallback;
     phpglfw_callback keycallback;
     phpglfw_callback charcallback;
     phpglfw_callback charmodscallback;
@@ -366,6 +366,188 @@ void phpglfw_shutdown_callbacks(void)
     //     zval_ptr_dtor(&_phpglfw_callback_charcallback);
     //     ZVAL_UNDEF(&_phpglfw_callback_charcallback);
     // }
+}
+static void phpglfw_callback_windowposcallback_handler(GLFWwindow* window, int xpos, int ypos)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], xpos);
+    ZVAL_LONG(&params[1], ypos);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowposcallback.fci.params = params;
+    window_obj->windowposcallback.fci.param_count = 2;
+    window_obj->windowposcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowposcallback.fci, &window_obj->windowposcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowsizecallback_handler(GLFWwindow* window, int width, int height)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], width);
+    ZVAL_LONG(&params[1], height);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowsizecallback.fci.params = params;
+    window_obj->windowsizecallback.fci.param_count = 2;
+    window_obj->windowsizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowsizecallback.fci, &window_obj->windowsizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowclosecallback_handler(GLFWwindow* window)
+{
+    zval return_val;
+
+    ZVAL_NULL(&return_val);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowclosecallback.fci.param_count = 0;
+    window_obj->windowclosecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowclosecallback.fci, &window_obj->windowclosecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+}
+
+static void phpglfw_callback_windowrefreshcallback_handler(GLFWwindow* window)
+{
+    zval return_val;
+
+    ZVAL_NULL(&return_val);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowrefreshcallback.fci.param_count = 0;
+    window_obj->windowrefreshcallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowrefreshcallback.fci, &window_obj->windowrefreshcallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+}
+
+static void phpglfw_callback_windowfocuscallback_handler(GLFWwindow* window, int focused)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], focused);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowfocuscallback.fci.params = params;
+    window_obj->windowfocuscallback.fci.param_count = 1;
+    window_obj->windowfocuscallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowfocuscallback.fci, &window_obj->windowfocuscallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowiconifycallback_handler(GLFWwindow* window, int iconified)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], iconified);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowiconifycallback.fci.params = params;
+    window_obj->windowiconifycallback.fci.param_count = 1;
+    window_obj->windowiconifycallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowiconifycallback.fci, &window_obj->windowiconifycallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowmaximizecallback_handler(GLFWwindow* window, int maximized)
+{
+    zval return_val;
+    zval *params = emalloc(sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], maximized);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowmaximizecallback.fci.params = params;
+    window_obj->windowmaximizecallback.fci.param_count = 1;
+    window_obj->windowmaximizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowmaximizecallback.fci, &window_obj->windowmaximizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowframebuffersizecallback_handler(GLFWwindow* window, int width, int height)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_LONG(&params[0], width);
+    ZVAL_LONG(&params[1], height);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowframebuffersizecallback.fci.params = params;
+    window_obj->windowframebuffersizecallback.fci.param_count = 2;
+    window_obj->windowframebuffersizecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowframebuffersizecallback.fci, &window_obj->windowframebuffersizecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
+}
+
+static void phpglfw_callback_windowcontentscalecallback_handler(GLFWwindow* window, float xscale, float yscale)
+{
+    zval return_val;
+    zval *params = emalloc(2 * sizeof(zval));
+
+    ZVAL_NULL(&return_val);
+
+    ZVAL_DOUBLE(&params[0], xscale);
+    ZVAL_DOUBLE(&params[1], yscale);
+
+    phpglfw_glfwwindow_object* window_obj = (phpglfw_glfwwindow_object*)glfwGetWindowUserPointer(window);
+
+    window_obj->windowcontentcalecallback.fci.params = params;
+    window_obj->windowcontentcalecallback.fci.param_count = 2;
+    window_obj->windowcontentcalecallback.fci.retval = &return_val;
+
+    zend_call_function(&window_obj->windowcontentcalecallback.fci, &window_obj->windowcontentcalecallback.fci_cache);
+
+    zval_ptr_dtor(&return_val);
+    efree(params);
 }
 
 static void phpglfw_callback_keycallback_handler(GLFWwindow* window, int key, int scancode, int action, int mods)
@@ -10640,6 +10822,69 @@ PHP_FUNCTION(glfwSetWindowAttrib)
     }
     GLFWwindow* window = phpglfw_glfwwindowptr_from_zval_ptr(window_zval);
     glfwSetWindowAttrib(window, attrib, value);
+} 
+
+/**
+ * glfwSetWindowPosCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowPosCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowposcallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowposcallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowPosCallback(obj_ptr->glfwwindow, phpglfw_callback_windowposcallback_handler);
+} 
+
+/**
+ * glfwSetWindowSizeCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowSizeCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowsizecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowsizecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowSizeCallback(obj_ptr->glfwwindow, phpglfw_callback_windowsizecallback_handler);
+} 
+
+/**
+ * glfwSetWindowCloseCallback
+ */ 
+PHP_FUNCTION(glfwSetWindowCloseCallback)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    zval *window_zval;
+    if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Of",  &window_zval, phpglfw_glfwwindow_ce, &fci, &fcc)) {
+        RETURN_THROWS();
+    }
+    phpglfw_glfwwindow_object *obj_ptr = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(window_zval));
+    Z_TRY_ADDREF(fci.function_name);
+    if (fcc.object) {
+        GC_ADDREF(fcc.object);
+    }
+    memcpy((void*)&obj_ptr->windowclosecallback.fci, (void*)&fci, sizeof(zend_fcall_info));
+    memcpy((void*)&obj_ptr->windowclosecallback.fci_cache, (void*)&fcc, sizeof(zend_fcall_info_cache));
+    glfwSetWindowCloseCallback(obj_ptr->glfwwindow, phpglfw_callback_windowclosecallback_handler);
 } 
 
 /**

--- a/phpglfw_functions.h
+++ b/phpglfw_functions.h
@@ -37,8 +37,13 @@ void phpglfw_glfwmonitor_object_minit_helper(void);
 void phpglfw_glfwcursor_object_minit_helper(void); 
 
 /**
- * Global callback handling
+ * callback handling
  */
+typedef struct {
+    zend_fcall_info fci;
+    zend_fcall_info_cache fci_cache;
+} phpglfw_callback;
+
 void phpglfw_init_callbacks(void);
 void phpglfw_shutdown_callbacks(void);
 

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -7636,6 +7636,75 @@ namespace {
     function glfwSetWindowAttrib(GLFWwindow $window, int $attrib, int $value) : void {};
  
     /**
+     * This function sets the position callback of the specified window, which is
+     * called when the window is moved.
+     * 
+     * The callback is provided with the screen position of the upper-left corner of
+     * the client area of the window.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowPosCallback($window, function($x, $y) {
+     *     echo "Window moved to: " . $x . ", " . $y . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowPosCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the size callback of the specified window, which is called
+     * when the window is resized.
+     * 
+     * The callback is provided with the size, in screen coordinates, of the client
+     * area of the window.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowSizeCallback($window, function($width, $height) {
+     *     echo "Window resized to: " . $width . "x" . $height . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowSizeCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the close callback of the specified window, which is
+     * called when the user attempts to close the window, for example by clicking
+     * the close widget in the title bar.
+     * 
+     * The close flag is set before this callback is called, but you can modify it
+     * at any time with glfwSetWindowShouldClose.
+     * 
+     * The close callback is not triggered by glfwDestroyWindow.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowCloseCallback($window, function() {
+     *     echo "Window close requested" . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowCloseCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
      * Processes all pending events.
      * 
      * This function processes only those events that are already in the event

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -7705,6 +7705,139 @@ namespace {
     function glfwSetWindowCloseCallback(GLFWwindow $window, callable $callback) : void {};
  
     /**
+     * This function sets the refresh callback of the specified window, which is
+     * called when the client area of the window needs to be redrawn, for example if
+     * the window has been exposed after having been covered by another window.
+     * 
+     * On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
+     * the window contents are saved off-screen, this callback may be called only
+     * very infrequently or never at all.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowRefreshCallback($window, function() {
+     *     echo "Window needs to be redrawn" . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowRefreshCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the focus callback of the specified window, which is
+     * called when the window gains or loses input focus.
+     * 
+     * After the focus callback is called for a window that lost input focus,
+     * synthetic key and mouse button release events will be generated for all such
+     * that had been pressed.  For more information, see glfwSetKeyCallback and
+     * glfwSetMouseButtonCallback.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowFocusCallback($window, function($focused) {
+     *     echo "Window focus changed to: " . $focused . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowFocusCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the iconification callback of the specified window, which
+     * is called when the window is iconified or restored.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowIconifyCallback($window, function($iconified) {
+     *     echo "Window iconified changed to: " . $iconified . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowIconifyCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the maximize callback of the specified window, which is
+     * called when the window is maximized or restored.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowMaximizeCallback($window, function($maximized) {
+     *     echo "Window maximized changed to: " . $maximized . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowMaximizeCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the framebuffer resize callback of the specified window,
+     * which is called when the framebuffer of the specified window is resized.
+     * 
+     * This callback is provided for convenience.  The equivalent functionality can
+     * be achieved by registering a window size callback and querying the
+     * framebuffer size within that callback.
+     * 
+     * Example:
+     * ```php
+     * glfwSetFramebufferSizeCallback($window, function($width, $height) {
+     *     echo "Framebuffer size changed to: " . $width . "x" . $height . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetFramebufferSizeCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the window content scale callback of the specified window,
+     * which is called when the content scale of the specified window changes.
+     * 
+     * This callback is provided for convenience.  The equivalent functionality can
+     * be achieved by registering a window size callback and querying the content
+     * scale within that callback.
+     * 
+     * Example:
+     * ```php
+     * glfwSetWindowContentScaleCallback($window, function($xscale, $yscale) {
+     *     echo "Window content scale changed to: " . $xscale . "x" . $yscale .
+     * PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetWindowContentScaleCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
      * Processes all pending events.
      * 
      * This function processes only those events that are already in the event

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -8329,6 +8329,146 @@ namespace {
     function glfwSetCharCallback(GLFWwindow $window, callable $callback) : void {};
  
     /**
+     * This function sets the character with modifiers callback of the specified
+     * window, which is called when a Unicode character is input regardless of what
+     * modifier keys are used.
+     * 
+     * The character with modifiers callback is intended for implementing custom
+     * Unicode character input. For regular Unicode text input, see the character
+     * callback.
+     * 
+     * Example:
+     * ```php
+     * glfwSetCharModsCallback($window, function($codepoint, $mods) {
+     *     echo "Character: " . mb_chr($codepoint) . ' with mods: ' . $mods .
+     * PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetCharModsCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the mouse button callback of the specified window, which
+     * is called when a mouse button is pressed or released.
+     * 
+     * Example:
+     * ```php
+     * glfwSetMouseButtonCallback($window, function($button, $action, $mods) {
+     *     if ($button == GLFW_MOUSE_BUTTON_LEFT && $action == GLFW_PRESS) {
+     *         echo "Left mouse button pressed" . PHP_EOL;
+     *     }
+     * });
+     * ```
+     * 
+     * When a window loses input focus, it will generate synthetic mouse button
+     * release events for all pressed mouse buttons. You can tell these events from
+     * user-generated events by the fact that the synthetic ones are generated after
+     * the focus loss event has been processed, i.e. after the window focus callback
+     * has been called.
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetMouseButtonCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the cursor position callback of the specified window,
+     * which is called when the cursor is moved.
+     * 
+     * The callback is provided with the position, in screen coordinates, relative
+     * to the upper-left corner of the client area of the window.
+     * 
+     * Example:
+     * ```php
+     * glfwSetCursorPosCallback($window, function($xpos, $ypos) {
+     *     echo "Cursor position: " . $xpos . ", " . $ypos . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetCursorPosCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the cursor boundary crossing callback of the specified
+     * window, which is called when the cursor enters or leaves the client area of
+     * the window.
+     * 
+     * Example:
+     * ```php
+     * glfwSetCursorEnterCallback($window, function($entered) {
+     *     if ($entered) {
+     *         echo "Cursor entered window" . PHP_EOL;
+     *     } else {
+     *         echo "Cursor left window" . PHP_EOL;
+     *     }
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetCursorEnterCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the scroll callback of the specified window, which is
+     * called when a scrolling device is used, such as a mouse wheel or scrolling
+     * area of a touchpad.
+     * 
+     * Example:
+     * ```php
+     * glfwSetScrollCallback($window, function($xoffset, $yoffset) {
+     *     echo "Scroll offset: " . $xoffset . ", " . $yoffset . PHP_EOL;
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetScrollCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
+     * This function sets the file drop callback of the specified window, which is
+     * called when one or more dragged files are dropped on the window.
+     * 
+     * Example:
+     * ```php
+     * glfwSetDropCallback($window, function($paths) {
+     *     echo "Dropped files:" . PHP_EOL;
+     *     foreach ($paths as $path) {
+     *         echo "  " . $path . PHP_EOL;
+     *     }
+     * });
+     * ```
+     * 
+     * 
+     * @param GLFWwindow $window The window whose callback to set.
+     * @param callable $callback 
+     * 
+     * @return void
+     */ 
+    function glfwSetDropCallback(GLFWwindow $window, callable $callback) : void {};
+ 
+    /**
      * Returns whether the specified joystick is present.
      * 
      * This function returns whether the specified joystick is present.

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -4551,21 +4551,6 @@ namespace {
     function glProvokingVertex(int $mode) : void {};
  
     /**
-     * create a new sync object and insert it into the GL command stream
-     * 
-     * @param int $condition Specifies the condition that must be met to set the
-     * sync object's state to signaled. condition must be
-     * <constant>GL_SYNC_GPU_COMMANDS_COMPLETE</constant>.
-     * @param int $flags Specifies a bitwise combination of flags controlling the
-     * behavior of the sync object. No flags are presently defined for this
-     * operation and flags must be zero. flags is a placeholder for anticipated
-     * future extensions of fence sync object capabilities.
-     * 
-     * @return int
-     */ 
-    function glFenceSync(int $condition, int $flags) : int {};
- 
-    /**
      * determine if a name corresponds to a sync object
      * 
      * @param int $sync Specifies a value that may be the name of a sync object.
@@ -4573,42 +4558,6 @@ namespace {
      * @return bool
      */ 
     function glIsSync(int $sync) : bool {};
- 
-    /**
-     * delete a sync object
-     * 
-     * @param int $sync The sync object to be deleted.
-     * 
-     * @return void
-     */ 
-    function glDeleteSync(int $sync) : void {};
- 
-    /**
-     * block and wait for a sync object to become signaled
-     * 
-     * @param int $sync The sync object whose status to wait on.
-     * @param int $flags A bitfield controlling the command flushing behavior. flags
-     * may be <constant>GL_SYNC_FLUSH_COMMANDS_BIT</constant>.
-     * @param int $timeout The timeout, specified in nanoseconds, for which the
-     * implementation should wait for sync to become signaled.
-     * 
-     * @return int
-     */ 
-    function glClientWaitSync(int $sync, int $flags, int $timeout) : int {};
- 
-    /**
-     * instruct the GL server to block until the specified sync object becomes
-     * signaled
-     * 
-     * @param int $sync Specifies the sync object whose status to wait on.
-     * @param int $flags A bitfield controlling the command flushing behavior. flags
-     * may be zero.
-     * @param int $timeout Specifies the timeout that the server should wait before
-     * continuing. timeout must be <constant>GL_TIMEOUT_IGNORED</constant>.
-     * 
-     * @return void
-     */ 
-    function glWaitSync(int $sync, int $flags, int $timeout) : void {};
  
     /**
      * glGetInteger64v
@@ -4619,22 +4568,6 @@ namespace {
      * @return void
      */ 
     function glGetInteger64v(int $pname, int &$data) : void {};
- 
-    /**
-     * query the properties of a sync object
-     * 
-     * @param int $sync Specifies the sync object whose properties to query.
-     * @param int $pname Specifies the parameter whose value to retrieve from the
-     * sync object specified in sync.
-     * @param int $count 
-     * @param int &$length Specifies the address of an variable to receive the
-     * number of integers placed in values.
-     * @param int &$values Specifies the address of an array to receive the values
-     * of the queried parameter.
-     * 
-     * @return void
-     */ 
-    function glGetSynciv(int $sync, int $pname, int $count, int &$length, int &$values) : void {};
  
     /**
      * glGetInteger64i_v
@@ -7172,8 +7105,7 @@ namespace {
      * or `NULL`
      * to not share resources.
      * 
-     * @return GLFWwindow The handle of the created window, or `NULL` if an
-     * `error` occurred.
+     * @return GLFWwindow
      */ 
     function glfwCreateWindow(int $width, int $height, string $title, ?GLFWmonitor $monitor = NULL, ?GLFWwindow $share = NULL) : GLFWwindow {};
  


### PR DESCRIPTION
This branch fixes, the callbacks being registered globally. Now instead they are attached to the internal window object. This finally also allows to handle multiple windows correctly. 