### PR TITLE
VG Color Improvements

### DIFF
--- a/docs/user-guide/vector-graphics/colors.md
+++ b/docs/user-guide/vector-graphics/colors.md
@@ -8,7 +8,12 @@ You can construct a color as follows:
 $color = new VGColor(0.5, 0.5, 0.5, 1.0); // r, g, b, a
 ```
 
-**Colors are immutable**, so you can't change the values of a color after it has been constructed.
+You can access the color components with using the properties `r`, `g`, `b` and `a`, please not that those values 
+are stored internally as 32-bit floats, so they are converted everytime you access them from userland.
+
+```php
+echo $color->r; // 0.5
+```
 
 ## Color Constants
 
@@ -16,6 +21,7 @@ PHP-GLFW provides a set of color constants.
 
 <figure markdown>
 ![PHP VectorGraphics Color Constants](./../../docs-assets/php-glfw/user_guide/vg/colors/color_contants.png){ width="100%" }
+  <figcaption>Run this <code>php examples/vg/color_constants.php</code></figcaption>
 </figure>
 
 A color contant can be retrieved with the `VGColor::` prefix. For example, to get the red color constant, use:
@@ -43,3 +49,84 @@ These are the available color constants:
 !!! note
     The `VGColor::random()` and `VGColor::randomGray()` functions return as you might have guessed a random color. 
     This can be useful for debugging purposes, for example when visualizing groups of objects.
+
+
+## Color Lightness
+
+You can lighten and darken a color with the `lighten()` and `darken()` functions. Both functions take a float value which represents the amount of lightness to add or remove. The value must be between 0 and 1.
+
+Internally the RGB is converted to HSL, the lightness is then modified and the color is converted back to RGB.
+
+<figure markdown>
+![PHP VectorGraphics Color Constants](./../../docs-assets/php-glfw/user_guide/vg/colors/color_lightness.png){ width="100%" }
+  <figcaption>Run this <code>php examples/vg/color_lightness.php</code></figcaption>
+</figure>
+
+```php
+// darken
+$darkerRed = VGColor::red()->darken(0.3);
+// lighten
+$ligherRed = VGColor::red()->lighten(0.3);
+```
+
+## Color Constrcutors 
+
+There are a few color constructors available:
+
+### From RGB
+
+Constructs a color from RGB values. The values must be between 0 and 1. 
+
+```php
+$color = VGColor::rgb(0.5, 0.5, 0.5); // Alpha is set to 1.
+$color = VGColor::rgba(0.5, 0.5, 0.5, 0.8);
+```
+
+### From HSL
+
+Constructs a color from HSL values. The values must be between 0 and 1.
+
+```php
+$color = VGColor::hsl(0.5, 0.5, 0.5); //  Alpha is set to 1.
+$color = VGColor::hsla(0.5, 0.5, 0.5, 0.8);
+```
+
+### From IRGB
+
+Constructs a color from RGB values. The values must be between 0 and 255.
+
+```php
+$white = VGColor::irgb(255, 255, 255); // Alpha is set to 255.
+$transparent = VGColor::irgb(255, 255, 255, 50);
+```
+
+## Inverting 
+
+You can invert a color with the `invert()` function. This function returns a new color.
+
+```php
+$inverted = VGColor::red()->invert();
+```
+
+## Conversion between Vectors
+
+You can convert a color to a vector with the `getVec3()` and `getVec4()` functions. You can also construct a color from a vector with the `fromVec3()` and `fromVec4()` functions.
+
+```php
+// VGColor(1.0, 0.0, 0.0, 1.0)
+$red = VGColor::fromVec3(new Vec3(1.0, 0.0, 0.0));
+```
+
+```php
+ // Vec3(1.0, 0.0, 0.0)
+$vec = VGColor::red()->getVec3();
+```
+
+This way you can utilize the vector functions to manipulate colors.
+
+```php
+$red = VGColor::red()->getVec3();
+$green = VGColor::green()->getVec3();
+
+$mixed = Vec3::mix($red, $green, 0.5);
+```

--- a/docs/user-guide/vector-graphics/text.md
+++ b/docs/user-guide/vector-graphics/text.md
@@ -1,0 +1,8 @@
+# Text & Fonts
+
+You can load fonts `ttf` files and render text with them.
+
+<figure markdown>
+![PHP VectorGraphics Color Constants](./../../docs-assets/php-glfw/user_guide/vg/text/intro.png){ width="100%" }
+  <figcaption>Run this <code>php examples/vg/text_intro.php</code></figcaption>
+</figure>

--- a/examples/99_example_helpers.php
+++ b/examples/99_example_helpers.php
@@ -360,7 +360,6 @@ class ExampleHelper
         // close bracket
         $vg->fillColori(22, 159, 255, 255);
         $x = $vg->text($x, $y, ')');
-        $vg->fill();
         $vg->restore();
     }
     

--- a/examples/vg/color_lightness.php
+++ b/examples/vg/color_lightness.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * We utilize the example helpers here to focus on what matter in this specifc example.
+ */
+require __DIR__ . '/../99_example_helpers.php';
+
+use GL\Texture\Texture2D;
+use GL\VectorGraphics\{VGAlign, VGContext, VGColor};
+
+$window = ExampleHelper::begin();
+
+// initalize the a vector graphics context
+$vg = new VGContext(VGContext::ANTIALIAS);
+
+
+function getHLSLabel(VGColor $color) {
+    $hsl = $color->getHSL();
+    return sprintf('HLS(%.2f, %.2f, %.2f)', $hsl->x, $hsl->y, $hsl->z);
+}
+
+// Main Loop
+// ---------------------------------------------------------------------------- 
+while (!glfwWindowShouldClose($window))
+{
+    // clear
+    glClearColor(0, 0, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+    // fetch the content scale of the window
+    $contentScaleX;
+    $contentScaleY;
+    glfwGetWindowContentScale($window, $contentScaleX, $contentScaleY);
+
+    // begin a new frame using the window size as the viewport size
+    $vg->beginFrame(ExampleHelper::WIN_WIDTH, ExampleHelper::WIN_HEIGHT, $contentScaleX);
+
+    ExampleHelper::drawCoordSys($vg);
+
+    $colors = [
+        'red',
+        'green',
+        'blue',
+    ];
+
+    $numOfLightSteps = 3;
+    $stepSize = 0.1;
+    $height = ExampleHelper::WIN_HEIGHT / count($colors);
+    $y =  $height * 0.5 - 25;
+    $gutter = 50;
+    $gutterX = 20;
+    $radius = $height / 2 - $gutter;
+
+    foreach($colors as $color) {
+        $x = ExampleHelper::WIN_WIDTH / 2;
+        $vg->beginPath();
+        $vg->circle($x, $y, $radius);
+        $vg->fillColor(VGColor::$color());
+        $vg->fill();
+
+        // render a text under the circle
+        $vg->beginPath();
+        $vg->fontSize(12);
+        $vg->textAlign(VGAlign::CENTER | VGAlign::MIDDLE);
+        $vg->fillColor(VGColor::white());
+        $vg->text($x, $y + $radius + 20, $color);
+        $vg->text($x, $y + $radius + 40, getHLSLabel(VGColor::$color()));
+
+        // render lighter versions of the color
+        for($lightenStep = 1; $lightenStep < $numOfLightSteps + 1; $lightenStep++) {
+            $newColor = VGColor::$color()->lighten($stepSize * $lightenStep);
+
+            $vg->beginPath();
+            $vg->fillColor($newColor);
+            $vg->circle($x + ($lightenStep * $radius * 2) + $gutterX * $lightenStep, $y, $radius);
+            $vg->fill();
+
+            // create a lighten label
+            $vg->beginPath();
+            $vg->fontSize(12);
+            $vg->textAlign(VGAlign::CENTER | VGAlign::MIDDLE);
+            $vg->fillColor(VGColor::white());
+            $vg->text($x + ($lightenStep * $radius * 2) + $gutterX * $lightenStep, $y + $radius + 20, 'lighten(' . ($stepSize * $lightenStep) . ')');
+            $vg->text($x + ($lightenStep * $radius * 2) + $gutterX * $lightenStep, $y + $radius + 40, getHLSLabel($newColor));
+        }
+
+        // same for the darken version
+        for($darkenStep = 1; $darkenStep < $numOfLightSteps + 1; $darkenStep++) {
+            $newColor = VGColor::$color()->darken($stepSize * $darkenStep);
+
+            $vg->beginPath();
+            $vg->fillColor($newColor);
+            $vg->circle($x - ($darkenStep * $radius * 2) - $gutterX * $darkenStep, $y, $radius);
+            $vg->fill();
+
+            // create a darken label
+            $vg->beginPath();
+            $vg->fontSize(12);
+            $vg->textAlign(VGAlign::CENTER | VGAlign::MIDDLE);
+            $vg->fillColor(VGColor::white());
+            $vg->text($x - ($darkenStep * $radius * 2) - $gutterX * $darkenStep, $y + $radius + 20, 'darken(' . ($stepSize * $darkenStep) . ')');
+            $vg->text($x - ($darkenStep * $radius * 2) - $gutterX * $darkenStep, $y + $radius + 40, getHLSLabel($newColor));
+        }
+
+        $y += $height;
+    }
+
+    // end the frame will dispatch all the draw commands to the GPU
+    $vg->endFrame();
+
+    // swap the windows framebuffer and
+    // poll queued window events.
+    glfwSwapBuffers($window);
+    glfwPollEvents();
+}
+
+ExampleHelper::stop($window);

--- a/examples/vg/text_intro.php
+++ b/examples/vg/text_intro.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * We utilize the example helpers here to focus on what matter in this specifc example.
+ */
+require __DIR__ . '/../99_example_helpers.php';
+
+use GL\Texture\Texture2D;
+use GL\VectorGraphics\{VGAlign, VGContext, VGColor};
+
+$window = ExampleHelper::begin();
+
+// initalize the a vector graphics context
+$vg = new VGContext(VGContext::ANTIALIAS);
+
+// Main Loop
+// ---------------------------------------------------------------------------- 
+while (!glfwWindowShouldClose($window))
+{
+    // clear
+    glClearColor(0, 0, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+    // fetch the content scale of the window
+    $contentScaleX;
+    $contentScaleY;
+    glfwGetWindowContentScale($window, $contentScaleX, $contentScaleY);
+
+    // begin a new frame using the window size as the viewport size
+    $vg->beginFrame(ExampleHelper::WIN_WIDTH, ExampleHelper::WIN_HEIGHT, $contentScaleX);
+
+    ExampleHelper::drawCoordSys($vg);
+
+    // Render a Hello World Text
+    $vg->fontSize(200.0);
+    $vg->textLetterSpacing(2.0);
+    $vg->textAlign(VGAlign::CENTER | VGAlign::MIDDLE);
+
+    // shadow text
+    $vg->beginPath();
+    $vg->fontBlur(4);
+    $vg->fillColor(VGColor::rgba(1.0, 1.0, 1.0, 0.5));
+    $vg->text(ExampleHelper::WIN_WIDTH / 2, ExampleHelper::WIN_HEIGHT / 2 + 10, "Hello World");
+    $vg->closePath();
+    
+    // actual text
+    $vg->beginPath();
+    $vg->fontBlur(0.0);
+    $vg->fillColor(VGColor::white());
+    $vg->text(ExampleHelper::WIN_WIDTH / 2, ExampleHelper::WIN_HEIGHT / 2, "Hello World");
+
+
+    // end the frame will dispatch all the draw commands to the GPU
+    $vg->endFrame();
+
+    // swap the windows framebuffer and
+    // poll queued window events.
+    glfwSwapBuffers($window);
+    glfwPollEvents();
+}
+
+ExampleHelper::stop($window);

--- a/generator/templates/phpglfw.stub.php.php
+++ b/generator/templates/phpglfw.stub.php.php
@@ -220,6 +220,15 @@ namespace GL\VectorGraphics
         public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
+
+        public function getHSLA() : \GL\Math\Vec4 {}
+        public function getHSL() : \GL\Math\Vec3 {}
+        public function getVec4() : \GL\Math\Vec4 {}
+        public function getVec3() : \GL\Math\Vec3 {}
+
+        public function darken(float $amount) : VGColor {}
+        public function lighten(float $amount) : VGColor {}
+        public function invert() : VGColor {}
     }
     
     class VGPaint {

--- a/generator/templates/phpglfw.stub.php.php
+++ b/generator/templates/phpglfw.stub.php.php
@@ -186,10 +186,12 @@ namespace GL\Buffer
 namespace GL\VectorGraphics
 {
     class VGColor {
-        //public static function rgb(float $r, float $g, float $b) : VGColor {}
-        //public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
-        //public static function irgb(int $r, int $g, int $b) : VGColor {}
-        //public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
+        public static function rgb(float $r, float $g, float $b) : VGColor {}
+        public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
+        public static function hsl(float $h, float $s, float $l) : VGColor {}
+        public static function hsla(float $h, float $s, float $l, float $a) : VGColor {}
+        public static function irgb(int $r, int $g, int $b) : VGColor {}
+        public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
         //public static function fromVec4(\GL\Math\Vec4 $vec) : VGColor {}
         //public static function fromVec3(\GL\Math\Vec3 $vec) : VGColor {}
 
@@ -211,6 +213,11 @@ namespace GL\VectorGraphics
         public static function lightGray() : VGColor {}
         public static function random() : VGColor {}
         public static function randomGray() : VGColor {}
+
+        public float $r;
+        public float $g;
+        public float $b;
+        public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
     }

--- a/generator/templates/phpglfw_vg.c.php
+++ b/generator/templates/phpglfw_vg.c.php
@@ -151,6 +151,68 @@ static HashTable *phpglfw_vgcolor_debug_info_handler(zend_object *object, int *i
     return ht;
 }
 
+static zval *phpglfw_vgcolor_read_prop_handler(zend_object *object, zend_string *member, int type, void **cache_slot, zval *rv) 
+{
+    phpglfw_vgcolor_object *obj_ptr = phpglfw_vgcolor_objectptr_from_zobj_p(object);
+
+	if ((type != BP_VAR_R && type != BP_VAR_IS)) {
+		zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor properties are virtual and cannot be referenced.");
+		rv = &EG( uninitialized_zval );
+	} else {
+
+        if (zend_string_equals_literal(member, "r")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[0]);
+        }
+        else if (zend_string_equals_literal(member, "g")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[1]);
+        }
+        else if (zend_string_equals_literal(member, "b")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[2]);
+        }
+        else if (zend_string_equals_literal(member, "a")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[3]);
+        }
+        else {
+            ZVAL_NULL(rv);
+        }
+	}
+
+	return rv;
+}
+
+static zval *phpglfw_vgcolor_write_prop_handler(zend_object *object, zend_string *member, zval *value, void **cache_slot) 
+{
+    if (Z_TYPE_P(value) == IS_LONG) {
+        convert_to_double(value);
+    }
+    
+    if (Z_TYPE_P(value) != IS_DOUBLE) {
+		zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor properties can only be of type 'float'.");
+        return value;
+    }
+    else {
+        phpglfw_vgcolor_object *obj_ptr = phpglfw_vgcolor_objectptr_from_zobj_p(object);
+
+        if (zend_string_equals_literal(member, "r")) {
+		    obj_ptr->nvgcolor.rgba[0] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "g")) {
+		    obj_ptr->nvgcolor.rgba[1] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "b")) {
+		    obj_ptr->nvgcolor.rgba[2] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "a")) {
+		    obj_ptr->nvgcolor.rgba[3] = Z_DVAL_P(value); 
+        }
+        else {
+		    zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor trying to write into a invalid property.");
+        }
+    }
+
+	return value;
+}
+
 PHP_METHOD(GL_VectorGraphics_VGColor, __construct)
 {
     double r, g, b, a;
@@ -160,6 +222,84 @@ PHP_METHOD(GL_VectorGraphics_VGColor, __construct)
 
     phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
     intern->nvgcolor = nvgRGBAf(r, g, b, a);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, rgb)
+{
+    double r, g, b;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "ddd", &r, &g, &b) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBAf(r, g, b, 1.0f);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, rgba)
+{
+    double r, g, b, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "dddd", &r, &g, &b, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBAf(r, g, b, a);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, hsl)
+{
+    double h, s, l;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "ddd", &h, &s, &l) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgHSLA(h, s, l, 255);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, hsla)
+{
+    double h, s, l, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "dddd", &h, &s, &l, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    // nanovg expects the alpha value to be a unsigned char here for some reason
+    // it is internally then converted back to a float -,- 
+    // i could fix this, but im lazy
+    unsigned char alpha = (unsigned char)(a * 255.0f);
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    color->nvgcolor = nvgHSLA(h, s, l, alpha);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, irgb)
+{
+    zend_long r, g, b;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "lll", &r, &g, &b) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBA(r, g, b, 255);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, irgba)
+{
+    zend_long r, g, b, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "llll", &r, &g, &b, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBA(r, g, b, a);
 }
 
 DEFINE_STATIC_VGCOLOR_METHOD(red, 1.0f, 0.0f, 0.0f, 1.0f);
@@ -194,6 +334,8 @@ PHP_METHOD(GL_VectorGraphics_VGColor, randomGray)
     float grayValue = (float)rand()/RAND_MAX;
     color->nvgcolor = nvgRGBAf(grayValue, grayValue, grayValue, 1.0f);
 }
+
+
 
 /**
  * VGPaint 
@@ -573,6 +715,8 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcolor_handlers.offset = XtOffsetOf(phpglfw_vgcolor_object, std);
     phpglfw_vgcolor_handlers.free_obj = phpglfw_vgcolor_free_handler;
     phpglfw_vgcolor_handlers.get_debug_info = phpglfw_vgcolor_debug_info_handler;
+    phpglfw_vgcolor_handlers.read_property = phpglfw_vgcolor_read_prop_handler;
+    phpglfw_vgcolor_handlers.write_property = phpglfw_vgcolor_write_prop_handler;
 
     // initialize and register the VectorGraphics Image class
     INIT_CLASS_ENTRY(tmp_ce, "GL\\VectorGraphics\\VGImage", class_GL_VectorGraphics_VGImage_methods);

--- a/generator/templates/phpglfw_vg.c.php
+++ b/generator/templates/phpglfw_vg.c.php
@@ -335,7 +335,100 @@ PHP_METHOD(GL_VectorGraphics_VGColor, randomGray)
     color->nvgcolor = nvgRGBAf(grayValue, grayValue, grayValue, 1.0f);
 }
 
+PHP_METHOD(GL_VectorGraphics_VGColor, getHSLA)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
 
+    object_init_ex(return_value, phpglfw_get_math_vec4_ce());
+    phpglfw_math_vec4_object *vec4 = phpglfw_math_vec4_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    nvgColorToHSLA(intern->nvgcolor, &vec4->data[0], &vec4->data[1], &vec4->data[2], &vec4->data[3]);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getHSL)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec3_ce());
+    phpglfw_math_vec3_object *vec3 = phpglfw_math_vec3_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    float throwaway;
+    nvgColorToHSLA(intern->nvgcolor, &vec3->data[0], &vec3->data[1], &vec3->data[2], &throwaway);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getVec4)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec4_ce());
+    phpglfw_math_vec4_object *vec4 = phpglfw_math_vec4_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    vec4->data[0] = intern->nvgcolor.r;
+    vec4->data[1] = intern->nvgcolor.g;
+    vec4->data[2] = intern->nvgcolor.b;
+    vec4->data[3] = intern->nvgcolor.a;
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getVec3)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec3_ce());
+    phpglfw_math_vec3_object *vec3 = phpglfw_math_vec3_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    vec3->data[0] = intern->nvgcolor.r;
+    vec3->data[1] = intern->nvgcolor.g;
+    vec3->data[2] = intern->nvgcolor.b;
+}
+
+
+// public function darken(float $amount) : VGColor {}
+// public function lighten(float $amount) : VGColor {}
+// public function saturate(float $amount) : VGColor {}
+// public function desaturate(float $amount) : VGColor {}
+// public function invert() : VGColor {}
+
+void adjust_hsl_l(INTERNAL_FUNCTION_PARAMETERS, double amount)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    float h, s, l, a;
+    nvgColorToHSLA(intern->nvgcolor, &h, &s, &l, &a);
+    l += amount;
+
+    color->nvgcolor = nvgHSL(h, s, l);
+    color->nvgcolor.a = a; // skip the conversion to unsigned char
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, darken)
+{
+    double amount;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &amount) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    adjust_hsl_l(INTERNAL_FUNCTION_PARAM_PASSTHRU, -amount);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, lighten)
+{
+    double amount;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &amount) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    adjust_hsl_l(INTERNAL_FUNCTION_PARAM_PASSTHRU, amount);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, invert)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    color->nvgcolor = nvgRGBAf(1.0f - intern->nvgcolor.r, 1.0f - intern->nvgcolor.g, 1.0f - intern->nvgcolor.b, intern->nvgcolor.a);
+}
 
 /**
  * VGPaint 

--- a/generator/templates/stubs/phpglfw.php.php
+++ b/generator/templates/stubs/phpglfw.php.php
@@ -1412,6 +1412,30 @@ namespace GL\VectorGraphics
         public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
+
+        /**
+         * Returns the color as a Vec4 where each component represents Hue, Saturation, Lightness and Alpha respectively.
+         */
+        public function getHSLA() : \GL\Math\Vec4 {}
+
+        /**
+         * Returns the color as a Vec3 where each component represents Hue, Saturation and Lightness respectively.
+         */
+        public function getHSL() : \GL\Math\Vec3 {}
+
+        /**
+         * Returns the color as a Vec4 where each component represents Red, Green, Blue and Alpha respectively.
+         */
+        public function getVec4() : \GL\Math\Vec4 {}
+
+        /**
+         * Returns the color as a Vec3 where each component represents Red, Green and Blue respectively.
+         */
+        public function getVec3() : \GL\Math\Vec3 {}
+
+        public function darken(float $amount) : VGColor {}
+        public function lighten(float $amount) : VGColor {}
+        public function invert() : VGColor {}
     }
     
     class VGPaint {

--- a/generator/templates/stubs/phpglfw.php.php
+++ b/generator/templates/stubs/phpglfw.php.php
@@ -1327,10 +1327,48 @@ namespace GL\Texture
 namespace GL\VectorGraphics
 {
     class VGColor {
-        //public static function rgb(float $r, float $g, float $b) : VGColor {}
-        //public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
-        //public static function irgb(int $r, int $g, int $b) : VGColor {}
-        //public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
+        public static function rgb(float $r, float $g, float $b) : VGColor {}
+        public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
+        /**
+         * HSL color constructor
+         * All values are in the range [0.0, 1.0]
+         *
+         * @param float $h Hue
+         * @param float $s Saturation
+         * @param float $l Lightness
+         */
+        public static function hsl(float $h, float $s, float $l) : VGColor {}
+
+        /**
+         * HSL with alpha color constructor
+         * All values are in the range [0.0, 1.0]
+         *
+         * @param float $h Hue
+         * @param float $s Saturation
+         * @param float $l Lightness
+         */
+        public static function hsla(float $h, float $s, float $l, float $a) : VGColor {}
+
+        /**
+         * RGB color constructor from integer values
+         * All values are in the range [0, 255]
+         *
+         * @param int $r Red
+         * @param int $g Green
+         * @param int $b Blue
+         */
+        public static function irgb(int $r, int $g, int $b) : VGColor {}
+
+        /**
+         * RGBA color constructor from integer values
+         * All values are in the range [0, 255]
+         *
+         * @param int $r Red
+         * @param int $g Green
+         * @param int $b Blue
+         * @param int $a Alpha
+         */
+        public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
         //public static function fromVec4(\GL\Math\Vec4 $vec) : VGColor {}
         //public static function fromVec3(\GL\Math\Vec3 $vec) : VGColor {}
 
@@ -1352,6 +1390,26 @@ namespace GL\VectorGraphics
         public static function lightGray() : VGColor {}
         public static function random() : VGColor {}
         public static function randomGray() : VGColor {} 
+
+        /**
+         * Virtual property for the red component of the color
+         */
+        public float $r;
+
+        /**
+         * Virtual property for the green component of the color
+         */
+        public float $g;
+
+        /**
+         * Virtual property for the blue component of the color
+         */
+        public float $b;
+
+        /**
+         * Virtual property for the alpha component of the color
+         */
+        public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Fill & Stroke: user-guide/vector-graphics/fill-vs-stroke.md
       - Shapes: user-guide/vector-graphics/shapes.md
       - Colors: user-guide/vector-graphics/colors.md
+      - Text & Fonts: user-guide/vector-graphics/text.md
     - Math & 3D Space: user-guide/math/
     - Offscreen & Headless Rendering: user-guide/offscreen/
     - Debugging: user-guide/debugging/

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -326,10 +326,12 @@ namespace GL\Buffer
 namespace GL\VectorGraphics
 {
     class VGColor {
-        //public static function rgb(float $r, float $g, float $b) : VGColor {}
-        //public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
-        //public static function irgb(int $r, int $g, int $b) : VGColor {}
-        //public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
+        public static function rgb(float $r, float $g, float $b) : VGColor {}
+        public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
+        public static function hsl(float $h, float $s, float $l) : VGColor {}
+        public static function hsla(float $h, float $s, float $l, float $a) : VGColor {}
+        public static function irgb(int $r, int $g, int $b) : VGColor {}
+        public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
         //public static function fromVec4(\GL\Math\Vec4 $vec) : VGColor {}
         //public static function fromVec3(\GL\Math\Vec3 $vec) : VGColor {}
 
@@ -351,6 +353,11 @@ namespace GL\VectorGraphics
         public static function lightGray() : VGColor {}
         public static function random() : VGColor {}
         public static function randomGray() : VGColor {}
+
+        public float $r;
+        public float $g;
+        public float $b;
+        public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
     }

--- a/phpglfw.stub.php
+++ b/phpglfw.stub.php
@@ -360,6 +360,15 @@ namespace GL\VectorGraphics
         public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
+
+        public function getHSLA() : \GL\Math\Vec4 {}
+        public function getHSL() : \GL\Math\Vec3 {}
+        public function getVec4() : \GL\Math\Vec4 {}
+        public function getVec3() : \GL\Math\Vec3 {}
+
+        public function darken(float $amount) : VGColor {}
+        public function lighten(float $amount) : VGColor {}
+        public function invert() : VGColor {}
     }
     
     class VGPaint {

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f5ec7f5760896375037d1202fccd28563f22306 */
+ * Stub hash: 08fa24b6afb25e10eb4bd4a4d23ec6113c2960ad */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -2803,6 +2803,45 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_GL_Buffer_UByteBuffer_reserve arginfo_class_GL_Buffer_BufferInterface_reserve
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_rgb, 0, 3, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, r, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, g, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, b, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_rgba, 0, 4, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, r, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, g, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, b, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, a, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_hsl, 0, 3, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, h, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, s, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, l, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_hsla, 0, 4, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, h, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, s, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, l, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, a, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_irgb, 0, 3, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, r, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, g, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, b, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_irgba, 0, 4, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, r, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, g, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, b, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, a, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_red, 0, 0, GL\\VectorGraphics\\VGColor, 0)
 ZEND_END_ARG_INFO()
 
@@ -3969,6 +4008,12 @@ ZEND_METHOD(GL_Buffer_UByteBuffer, clear);
 ZEND_METHOD(GL_Buffer_UByteBuffer, size);
 ZEND_METHOD(GL_Buffer_UByteBuffer, capacity);
 ZEND_METHOD(GL_Buffer_UByteBuffer, reserve);
+ZEND_METHOD(GL_VectorGraphics_VGColor, rgb);
+ZEND_METHOD(GL_VectorGraphics_VGColor, rgba);
+ZEND_METHOD(GL_VectorGraphics_VGColor, hsl);
+ZEND_METHOD(GL_VectorGraphics_VGColor, hsla);
+ZEND_METHOD(GL_VectorGraphics_VGColor, irgb);
+ZEND_METHOD(GL_VectorGraphics_VGColor, irgba);
 ZEND_METHOD(GL_VectorGraphics_VGColor, red);
 ZEND_METHOD(GL_VectorGraphics_VGColor, green);
 ZEND_METHOD(GL_VectorGraphics_VGColor, blue);
@@ -4942,6 +4987,12 @@ static const zend_function_entry class_GL_Buffer_UByteBuffer_methods[] = {
 
 
 static const zend_function_entry class_GL_VectorGraphics_VGColor_methods[] = {
+	ZEND_ME(GL_VectorGraphics_VGColor, rgb, arginfo_class_GL_VectorGraphics_VGColor_rgb, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, rgba, arginfo_class_GL_VectorGraphics_VGColor_rgba, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, hsl, arginfo_class_GL_VectorGraphics_VGColor_hsl, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, hsla, arginfo_class_GL_VectorGraphics_VGColor_hsla, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, irgb, arginfo_class_GL_VectorGraphics_VGColor_irgb, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, irgba, arginfo_class_GL_VectorGraphics_VGColor_irgba, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(GL_VectorGraphics_VGColor, red, arginfo_class_GL_VectorGraphics_VGColor_red, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(GL_VectorGraphics_VGColor, green, arginfo_class_GL_VectorGraphics_VGColor_green, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(GL_VectorGraphics_VGColor, blue, arginfo_class_GL_VectorGraphics_VGColor_blue, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)

--- a/phpglfw_arginfo.h
+++ b/phpglfw_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 08fa24b6afb25e10eb4bd4a4d23ec6113c2960ad */
+ * Stub hash: 13b267516805868812d843c1565eb7db12d828b6 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_glCullFace, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
@@ -2886,6 +2886,22 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor___construct, 0, 0
 	ZEND_ARG_TYPE_INFO(0, a, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_GL_VectorGraphics_VGColor_getHSLA arginfo_class_GL_Math_Vec4_copy
+
+#define arginfo_class_GL_VectorGraphics_VGColor_getHSL arginfo_class_GL_Math_Vec3_copy
+
+#define arginfo_class_GL_VectorGraphics_VGColor_getVec4 arginfo_class_GL_Math_Vec4_copy
+
+#define arginfo_class_GL_VectorGraphics_VGColor_getVec3 arginfo_class_GL_Math_Vec3_copy
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGColor_darken, 0, 1, GL\\VectorGraphics\\VGColor, 0)
+	ZEND_ARG_TYPE_INFO(0, amount, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_GL_VectorGraphics_VGColor_lighten arginfo_class_GL_VectorGraphics_VGColor_darken
+
+#define arginfo_class_GL_VectorGraphics_VGColor_invert arginfo_class_GL_VectorGraphics_VGColor_red
+
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_GL_VectorGraphics_VGImage_makePaint, 0, 4, GL\\VectorGraphics\\VGPaint, 0)
 	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
@@ -4033,6 +4049,13 @@ ZEND_METHOD(GL_VectorGraphics_VGColor, lightGray);
 ZEND_METHOD(GL_VectorGraphics_VGColor, random);
 ZEND_METHOD(GL_VectorGraphics_VGColor, randomGray);
 ZEND_METHOD(GL_VectorGraphics_VGColor, __construct);
+ZEND_METHOD(GL_VectorGraphics_VGColor, getHSLA);
+ZEND_METHOD(GL_VectorGraphics_VGColor, getHSL);
+ZEND_METHOD(GL_VectorGraphics_VGColor, getVec4);
+ZEND_METHOD(GL_VectorGraphics_VGColor, getVec3);
+ZEND_METHOD(GL_VectorGraphics_VGColor, darken);
+ZEND_METHOD(GL_VectorGraphics_VGColor, lighten);
+ZEND_METHOD(GL_VectorGraphics_VGColor, invert);
 ZEND_METHOD(GL_VectorGraphics_VGImage, makePaint);
 ZEND_METHOD(GL_VectorGraphics_VGImage, makePaintCentered);
 ZEND_METHOD(GL_VectorGraphics_VGContext, __construct);
@@ -5012,6 +5035,13 @@ static const zend_function_entry class_GL_VectorGraphics_VGColor_methods[] = {
 	ZEND_ME(GL_VectorGraphics_VGColor, random, arginfo_class_GL_VectorGraphics_VGColor_random, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(GL_VectorGraphics_VGColor, randomGray, arginfo_class_GL_VectorGraphics_VGColor_randomGray, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(GL_VectorGraphics_VGColor, __construct, arginfo_class_GL_VectorGraphics_VGColor___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, getHSLA, arginfo_class_GL_VectorGraphics_VGColor_getHSLA, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, getHSL, arginfo_class_GL_VectorGraphics_VGColor_getHSL, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, getVec4, arginfo_class_GL_VectorGraphics_VGColor_getVec4, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, getVec3, arginfo_class_GL_VectorGraphics_VGColor_getVec3, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, darken, arginfo_class_GL_VectorGraphics_VGColor_darken, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, lighten, arginfo_class_GL_VectorGraphics_VGColor_lighten, ZEND_ACC_PUBLIC)
+	ZEND_ME(GL_VectorGraphics_VGColor, invert, arginfo_class_GL_VectorGraphics_VGColor_invert, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/phpglfw_vg.c
+++ b/phpglfw_vg.c
@@ -335,7 +335,100 @@ PHP_METHOD(GL_VectorGraphics_VGColor, randomGray)
     color->nvgcolor = nvgRGBAf(grayValue, grayValue, grayValue, 1.0f);
 }
 
+PHP_METHOD(GL_VectorGraphics_VGColor, getHSLA)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
 
+    object_init_ex(return_value, phpglfw_get_math_vec4_ce());
+    phpglfw_math_vec4_object *vec4 = phpglfw_math_vec4_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    nvgColorToHSLA(intern->nvgcolor, &vec4->data[0], &vec4->data[1], &vec4->data[2], &vec4->data[3]);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getHSL)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec3_ce());
+    phpglfw_math_vec3_object *vec3 = phpglfw_math_vec3_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    float throwaway;
+    nvgColorToHSLA(intern->nvgcolor, &vec3->data[0], &vec3->data[1], &vec3->data[2], &throwaway);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getVec4)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec4_ce());
+    phpglfw_math_vec4_object *vec4 = phpglfw_math_vec4_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    vec4->data[0] = intern->nvgcolor.r;
+    vec4->data[1] = intern->nvgcolor.g;
+    vec4->data[2] = intern->nvgcolor.b;
+    vec4->data[3] = intern->nvgcolor.a;
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, getVec3)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_math_vec3_ce());
+    phpglfw_math_vec3_object *vec3 = phpglfw_math_vec3_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    vec3->data[0] = intern->nvgcolor.r;
+    vec3->data[1] = intern->nvgcolor.g;
+    vec3->data[2] = intern->nvgcolor.b;
+}
+
+
+// public function darken(float $amount) : VGColor {}
+// public function lighten(float $amount) : VGColor {}
+// public function saturate(float $amount) : VGColor {}
+// public function desaturate(float $amount) : VGColor {}
+// public function invert() : VGColor {}
+
+void adjust_hsl_l(INTERNAL_FUNCTION_PARAMETERS, double amount)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    float h, s, l, a;
+    nvgColorToHSLA(intern->nvgcolor, &h, &s, &l, &a);
+    l += amount;
+
+    color->nvgcolor = nvgHSL(h, s, l);
+    color->nvgcolor.a = a; // skip the conversion to unsigned char
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, darken)
+{
+    double amount;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &amount) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    adjust_hsl_l(INTERNAL_FUNCTION_PARAM_PASSTHRU, -amount);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, lighten)
+{
+    double amount;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &amount) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    adjust_hsl_l(INTERNAL_FUNCTION_PARAM_PASSTHRU, amount);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, invert)
+{
+    phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    color->nvgcolor = nvgRGBAf(1.0f - intern->nvgcolor.r, 1.0f - intern->nvgcolor.g, 1.0f - intern->nvgcolor.b, intern->nvgcolor.a);
+}
 
 /**
  * VGPaint 

--- a/phpglfw_vg.c
+++ b/phpglfw_vg.c
@@ -151,6 +151,68 @@ static HashTable *phpglfw_vgcolor_debug_info_handler(zend_object *object, int *i
     return ht;
 }
 
+static zval *phpglfw_vgcolor_read_prop_handler(zend_object *object, zend_string *member, int type, void **cache_slot, zval *rv) 
+{
+    phpglfw_vgcolor_object *obj_ptr = phpglfw_vgcolor_objectptr_from_zobj_p(object);
+
+	if ((type != BP_VAR_R && type != BP_VAR_IS)) {
+		zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor properties are virtual and cannot be referenced.");
+		rv = &EG( uninitialized_zval );
+	} else {
+
+        if (zend_string_equals_literal(member, "r")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[0]);
+        }
+        else if (zend_string_equals_literal(member, "g")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[1]);
+        }
+        else if (zend_string_equals_literal(member, "b")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[2]);
+        }
+        else if (zend_string_equals_literal(member, "a")) {
+		    ZVAL_DOUBLE(rv, obj_ptr->nvgcolor.rgba[3]);
+        }
+        else {
+            ZVAL_NULL(rv);
+        }
+	}
+
+	return rv;
+}
+
+static zval *phpglfw_vgcolor_write_prop_handler(zend_object *object, zend_string *member, zval *value, void **cache_slot) 
+{
+    if (Z_TYPE_P(value) == IS_LONG) {
+        convert_to_double(value);
+    }
+    
+    if (Z_TYPE_P(value) != IS_DOUBLE) {
+		zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor properties can only be of type 'float'.");
+        return value;
+    }
+    else {
+        phpglfw_vgcolor_object *obj_ptr = phpglfw_vgcolor_objectptr_from_zobj_p(object);
+
+        if (zend_string_equals_literal(member, "r")) {
+		    obj_ptr->nvgcolor.rgba[0] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "g")) {
+		    obj_ptr->nvgcolor.rgba[1] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "b")) {
+		    obj_ptr->nvgcolor.rgba[2] = Z_DVAL_P(value); 
+        }
+        else if (zend_string_equals_literal(member, "a")) {
+		    obj_ptr->nvgcolor.rgba[3] = Z_DVAL_P(value); 
+        }
+        else {
+		    zend_throw_error(NULL, "GL\\VectorGraphics\\VGColor trying to write into a invalid property.");
+        }
+    }
+
+	return value;
+}
+
 PHP_METHOD(GL_VectorGraphics_VGColor, __construct)
 {
     double r, g, b, a;
@@ -160,6 +222,84 @@ PHP_METHOD(GL_VectorGraphics_VGColor, __construct)
 
     phpglfw_vgcolor_object *intern = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(getThis()));
     intern->nvgcolor = nvgRGBAf(r, g, b, a);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, rgb)
+{
+    double r, g, b;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "ddd", &r, &g, &b) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBAf(r, g, b, 1.0f);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, rgba)
+{
+    double r, g, b, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "dddd", &r, &g, &b, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBAf(r, g, b, a);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, hsl)
+{
+    double h, s, l;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "ddd", &h, &s, &l) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgHSLA(h, s, l, 255);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, hsla)
+{
+    double h, s, l, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "dddd", &h, &s, &l, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    // nanovg expects the alpha value to be a unsigned char here for some reason
+    // it is internally then converted back to a float -,- 
+    // i could fix this, but im lazy
+    unsigned char alpha = (unsigned char)(a * 255.0f);
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+
+    color->nvgcolor = nvgHSLA(h, s, l, alpha);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, irgb)
+{
+    zend_long r, g, b;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "lll", &r, &g, &b) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBA(r, g, b, 255);
+}
+
+PHP_METHOD(GL_VectorGraphics_VGColor, irgba)
+{
+    zend_long r, g, b, a;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() , "llll", &r, &g, &b, &a) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    object_init_ex(return_value, phpglfw_get_vg_vgcolor_ce());
+    phpglfw_vgcolor_object *color = phpglfw_vgcolor_objectptr_from_zobj_p(Z_OBJ_P(return_value));
+    color->nvgcolor = nvgRGBA(r, g, b, a);
 }
 
 DEFINE_STATIC_VGCOLOR_METHOD(red, 1.0f, 0.0f, 0.0f, 1.0f);
@@ -194,6 +334,8 @@ PHP_METHOD(GL_VectorGraphics_VGColor, randomGray)
     float grayValue = (float)rand()/RAND_MAX;
     color->nvgcolor = nvgRGBAf(grayValue, grayValue, grayValue, 1.0f);
 }
+
+
 
 /**
  * VGPaint 
@@ -1568,6 +1710,8 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcolor_handlers.offset = XtOffsetOf(phpglfw_vgcolor_object, std);
     phpglfw_vgcolor_handlers.free_obj = phpglfw_vgcolor_free_handler;
     phpglfw_vgcolor_handlers.get_debug_info = phpglfw_vgcolor_debug_info_handler;
+    phpglfw_vgcolor_handlers.read_property = phpglfw_vgcolor_read_prop_handler;
+    phpglfw_vgcolor_handlers.write_property = phpglfw_vgcolor_write_prop_handler;
 
     // initialize and register the VectorGraphics Image class
     INIT_CLASS_ENTRY(tmp_ce, "GL\\VectorGraphics\\VGImage", class_GL_VectorGraphics_VGImage_methods);

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -2272,10 +2272,12 @@ namespace GL\Texture
 namespace GL\VectorGraphics
 {
     class VGColor {
-        //public static function rgb(float $r, float $g, float $b) : VGColor {}
-        //public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
-        //public static function irgb(int $r, int $g, int $b) : VGColor {}
-        //public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
+        public static function rgb(float $r, float $g, float $b) : VGColor {}
+        public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
+        public static function hsl(float $h, float $s, float $l) : VGColor {}
+        public static function hsla(float $h, float $s, float $l, float $a) : VGColor {}
+        public static function irgb(int $r, int $g, int $b) : VGColor {}
+        public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
         //public static function fromVec4(\GL\Math\Vec4 $vec) : VGColor {}
         //public static function fromVec3(\GL\Math\Vec3 $vec) : VGColor {}
 
@@ -2297,6 +2299,26 @@ namespace GL\VectorGraphics
         public static function lightGray() : VGColor {}
         public static function random() : VGColor {}
         public static function randomGray() : VGColor {} 
+
+        /**
+         * Virtual property for the red component of the color
+         */
+        public float $r;
+
+        /**
+         * Virtual property for the green component of the color
+         */
+        public float $g;
+
+        /**
+         * Virtual property for the blue component of the color
+         */
+        public float $b;
+
+        /**
+         * Virtual property for the alpha component of the color
+         */
+        public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
     }

--- a/stubs/phpglfw.php
+++ b/stubs/phpglfw.php
@@ -2274,9 +2274,45 @@ namespace GL\VectorGraphics
     class VGColor {
         public static function rgb(float $r, float $g, float $b) : VGColor {}
         public static function rgba(float $r, float $g, float $b, float $a) : VGColor {}
+        /**
+         * HSL color constructor
+         * All values are in the range [0.0, 1.0]
+         *
+         * @param float $h Hue
+         * @param float $s Saturation
+         * @param float $l Lightness
+         */
         public static function hsl(float $h, float $s, float $l) : VGColor {}
+
+        /**
+         * HSL with alpha color constructor
+         * All values are in the range [0.0, 1.0]
+         *
+         * @param float $h Hue
+         * @param float $s Saturation
+         * @param float $l Lightness
+         */
         public static function hsla(float $h, float $s, float $l, float $a) : VGColor {}
+
+        /**
+         * RGB color constructor from integer values
+         * All values are in the range [0, 255]
+         *
+         * @param int $r Red
+         * @param int $g Green
+         * @param int $b Blue
+         */
         public static function irgb(int $r, int $g, int $b) : VGColor {}
+
+        /**
+         * RGBA color constructor from integer values
+         * All values are in the range [0, 255]
+         *
+         * @param int $r Red
+         * @param int $g Green
+         * @param int $b Blue
+         * @param int $a Alpha
+         */
         public static function irgba(int $r, int $g, int $b, int $a) : VGColor {}
         //public static function fromVec4(\GL\Math\Vec4 $vec) : VGColor {}
         //public static function fromVec3(\GL\Math\Vec3 $vec) : VGColor {}
@@ -2321,6 +2357,30 @@ namespace GL\VectorGraphics
         public float $a;
 
         public function __construct(float $r, float $g, float $b, float $a) {}
+
+        /**
+         * Returns the color as a Vec4 where each component represents Hue, Saturation, Lightness and Alpha respectively.
+         */
+        public function getHSLA() : \GL\Math\Vec4 {}
+
+        /**
+         * Returns the color as a Vec3 where each component represents Hue, Saturation and Lightness respectively.
+         */
+        public function getHSL() : \GL\Math\Vec3 {}
+
+        /**
+         * Returns the color as a Vec4 where each component represents Red, Green, Blue and Alpha respectively.
+         */
+        public function getVec4() : \GL\Math\Vec4 {}
+
+        /**
+         * Returns the color as a Vec3 where each component represents Red, Green and Blue respectively.
+         */
+        public function getVec3() : \GL\Math\Vec3 {}
+
+        public function darken(float $amount) : VGColor {}
+        public function lighten(float $amount) : VGColor {}
+        public function invert() : VGColor {}
     }
     
     class VGPaint {

--- a/tests/VG/VGColorTest.php
+++ b/tests/VG/VGColorTest.php
@@ -68,5 +68,75 @@ class VGColorTest extends \PHPUnit\Framework\TestCase
         $this->assertEqualsColor(1.0, 0.0, 0.0, 0.4, $color);
     }
 
-    
+    public function testGetHSLA() : void
+    {
+        $color = VGColor::rgb(1.0, 0.0, 0.0);
+        $hsla = $color->getHSLA();
+
+        $this->assertEqualsWithDelta(0.0, $hsla->x, 0.005);
+        $this->assertEqualsWithDelta(1.0, $hsla->y, 0.005);
+        $this->assertEqualsWithDelta(0.5, $hsla->z, 0.005);
+        $this->assertEqualsWithDelta(1.0, $hsla->w, 0.005);        
+    }
+
+    public function testGetHSL() : void
+    {
+        $color = VGColor::rgb(1.0, 0.0, 0.0);
+        $hsl = $color->getHSL();
+
+        $this->assertEqualsWithDelta(0.0, $hsl->x, 0.005);
+        $this->assertEqualsWithDelta(1.0, $hsl->y, 0.005);
+        $this->assertEqualsWithDelta(0.5, $hsl->z, 0.005);
+    }
+
+    public function testGetVec4() : void
+    {
+        $color = VGColor::rgba(0.1, 0.2, 0.3, 0.4);
+        $vec4 = $color->getVec4();
+
+        $this->assertEqualsWithDelta(0.1, $vec4->x, 0.005);
+        $this->assertEqualsWithDelta(0.2, $vec4->y, 0.005);
+        $this->assertEqualsWithDelta(0.3, $vec4->z, 0.005);
+        $this->assertEqualsWithDelta(0.4, $vec4->w, 0.005);
+    }
+
+    public function testGetVec3() : void
+    {
+        $color = VGColor::rgb(0.1, 0.2, 0.3);
+        $vec3 = $color->getVec3();
+
+        $this->assertEqualsWithDelta(0.1, $vec3->x, 0.005);
+        $this->assertEqualsWithDelta(0.2, $vec3->y, 0.005);
+        $this->assertEqualsWithDelta(0.3, $vec3->z, 0.005);
+    }
+
+    public function testDarken() : void
+    {
+        $color = VGColor::hsl(0.5, 1.0, 0.5);
+        $darker = $color->darken(0.1)->getHSL();
+
+        $this->assertEqualsWithDelta(0.5, $darker->x, 0.005);
+        $this->assertEqualsWithDelta(1.0, $darker->y, 0.005);
+        $this->assertEqualsWithDelta(0.4, $darker->z, 0.005);
+    }
+
+    public function testLighten() : void
+    {
+        $color = VGColor::hsl(0.5, 1.0, 0.5);
+        $lighter = $color->lighten(0.1)->getHSL();
+
+        $this->assertEqualsWithDelta(0.5, $lighter->x, 0.005);
+        $this->assertEqualsWithDelta(1.0, $lighter->y, 0.005);
+        $this->assertEqualsWithDelta(0.6, $lighter->z, 0.005);
+    }
+
+    public function testInvert() : void
+    {
+        $color = VGColor::rgb(0.1, 0.2, 0.3);
+        $inverted = $color->invert()->getVec3();
+
+        $this->assertEqualsWithDelta(0.9, $inverted->x, 0.005);
+        $this->assertEqualsWithDelta(0.8, $inverted->y, 0.005);
+        $this->assertEqualsWithDelta(0.7, $inverted->z, 0.005);
+    }
 }

--- a/tests/VG/VGColorTest.php
+++ b/tests/VG/VGColorTest.php
@@ -1,0 +1,72 @@
+<?php 
+
+namespace GL\Tests\VG;
+
+use GL\VectorGraphics\VGColor;
+
+class VGColorTest extends \PHPUnit\Framework\TestCase
+{
+    private function assertEqualsColor($x, $y, $z, $a, VGColor $color)
+    {
+        $this->assertEqualsWithDelta($x, $color->r, 0.005);
+        $this->assertEqualsWithDelta($y, $color->g, 0.005);
+        $this->assertEqualsWithDelta($z, $color->b, 0.005);
+        $this->assertEqualsWithDelta($a, $color->a, 0.005);
+    }
+
+    public function testReadAndWriteProperties() : void
+    {
+        $color = new VGColor(0.1, 0.2, 0.3, 0.4);
+        $this->assertEqualsColor(0.1, 0.2, 0.3, 0.4, $color);
+
+        $color->r = 0.5;
+        $color->g = 0.6;
+        $color->b = 0.7;
+        $color->a = 0.8;
+        $this->assertEqualsColor(0.5, 0.6, 0.7, 0.8, $color);
+    }
+
+    public function testConstructorRGB() : void
+    {
+        $color = VGColor::rgb(0.1, 0.2, 0.3);
+        $this->assertEqualsColor(0.1, 0.2, 0.3, 1.0, $color);
+    }
+
+    public function testConstructorRGBA() : void
+    {
+        $color = VGColor::rgba(0.1, 0.2, 0.3, 0.4);
+        $this->assertEqualsColor(0.1, 0.2, 0.3, 0.4, $color);
+    }
+
+    // public function testConstructorHex() : void
+    // {
+    //     $color = VGColor::hex(0x123456);
+    //     $this->assertEqualsColor(0.07, 0.20, 0.34, 1.0, $color);
+    // }
+
+    public function testConstructorIRGB() : void
+    {
+        $color = VGColor::irgb(10, 20, 30);
+        $this->assertEqualsColor(0.039, 0.078, 0.117, 1.0, $color);
+    }
+
+    public function testConstructorIRGBA() : void
+    {
+        $color = VGColor::irgba(10, 20, 30, 40);
+        $this->assertEqualsColor(0.039, 0.078, 0.117, 0.157, $color);
+    }
+
+    public function testConstructorHSL() : void
+    {
+        $color = VGColor::hsl(0, 1.0, 0.5);
+        $this->assertEqualsColor(1.0, 0.0, 0.0, 1.0, $color);
+    }
+
+    public function testConstructorHSLA() : void
+    {
+        $color = VGColor::hsla(0, 1.0, 0.5, 0.4);
+        $this->assertEqualsColor(1.0, 0.0, 0.0, 0.4, $color);
+    }
+
+    
+}

--- a/vendor/nanovg/src/nanovg.c
+++ b/vendor/nanovg/src/nanovg.c
@@ -428,6 +428,8 @@ void nvgEndFrame(NVGcontext* ctx)
 	}
 }
 
+
+
 NVGcolor nvgRGB(unsigned char r, unsigned char g, unsigned char b)
 {
 	return nvgRGBA(r,g,b,255);
@@ -506,6 +508,8 @@ static float nvg__hue(float h, float m1, float m2)
 	return m1;
 }
 
+
+
 NVGcolor nvgHSLA(float h, float s, float l, unsigned char a)
 {
 	float m1, m2;
@@ -521,6 +525,45 @@ NVGcolor nvgHSLA(float h, float s, float l, unsigned char a)
 	col.b = nvg__clampf(nvg__hue(h - 1.0f/3.0f, m1, m2), 0.0f, 1.0f);
 	col.a = a/255.0f;
 	return col;
+}
+
+void nvgColorToHSLA(NVGcolor color, float* h, float* s, float* l, float* a) {
+    float r = color.r;
+    float g = color.g;
+    float b = color.b;
+    *a = color.a;
+
+    float max = fmaxf(r, fmaxf(g, b));
+    float min = fminf(r, fminf(g, b));
+    float delta = max - min;
+
+    *l = (max + min) / 2;
+
+    if (delta == 0) {
+        *h = 0;
+        *s = 0;
+    } else {
+        *s = delta / (1 - fabsf(2 * *l - 1));
+
+        float deltaR = (((max - r) / 6) + (delta / 2)) / delta;
+        float deltaG = (((max - g) / 6) + (delta / 2)) / delta;
+        float deltaB = (((max - b) / 6) + (delta / 2)) / delta;
+
+        if (r == max) {
+            *h = deltaB - deltaG;
+        } else if (g == max) {
+            *h = (1.0f / 3.0f) + deltaR - deltaB;
+        } else {
+            *h = (2.0f / 3.0f) + deltaG - deltaR;
+        }
+
+        if (*h < 0) {
+            *h += 1;
+        }
+        if (*h > 1) {
+            *h -= 1;
+        }
+    }
 }
 
 void nvgTransformIdentity(float* t)

--- a/vendor/nanovg/src/nanovg.h
+++ b/vendor/nanovg/src/nanovg.h
@@ -217,6 +217,11 @@ NVGcolor nvgHSL(float h, float s, float l);
 // HSL values are all in range [0..1], alpha in range [0..255]
 NVGcolor nvgHSLA(float h, float s, float l, unsigned char a);
 
+// Converts a NVGcolor to its HSLA (Hue, Saturation, Lightness, Alpha) representation.
+// The converted values are stored in the provided pointers.
+void nvgColorToHSLA(NVGcolor color, float* h, float* s, float* l, float* a);
+
+
 //
 // State Handling
 //


### PR DESCRIPTION
This PR adds a bunch of `VGColor` constructor functions and a few utility functions. As-well as a user guide on how to use the `VGColor` class.

**Changes**
 * Allow read & write access to `VColor` `r`, `g`, `b` and `a` values.
 * Added example code for darken and lighten colors.
 * Added Vector graphics color user guide.
 * Added HSL functions
 * Added casting functions between colors and `Vec3`, `Vec4`