### PR TITLE
PHP 8.5 Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Install PHPUnit
       run: |
-        composer install"
+        composer install
       
     - name: Run PHPUnit
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-22.04']
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['latest']
         preinstalled-glfw: ['libglfw3-dev', '']
     
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['macos-latest']
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['latest']
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         echo 'extension=glfw.so' >> /opt/homebrew/etc/php/${{ matrix.php-versions }}/php.ini
     
     - name: Install PHPUnit
-      run: composer install"
+      run: composer install
     
     # On MacOS we currently exclude all tests requiring glfwinit to work.. 
     # Initializing it in the Github action results in a segmentation fault. 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Install PHPUnit
       run: |
-        composer require "phpunit/phpunit:9.6.3"
+        composer install"
       
     - name: Run PHPUnit
       run: |
@@ -109,7 +109,7 @@ jobs:
         echo 'extension=glfw.so' >> /opt/homebrew/etc/php/${{ matrix.php-versions }}/php.ini
     
     - name: Install PHPUnit
-      run: composer require "phpunit/phpunit:9.6.3"
+      run: composer install"
     
     # On MacOS we currently exclude all tests requiring glfwinit to work.. 
     # Initializing it in the Github action results in a segmentation fault. 

--- a/.github/workflows/macos_installer.yml
+++ b/.github/workflows/macos_installer.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['macos-latest']
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/macos_installer.yml
+++ b/.github/workflows/macos_installer.yml
@@ -28,7 +28,7 @@ jobs:
       run: php -r "copy('https://raw.githubusercontent.com/mario-deluna/php-glfw/master/install/macos-installer.php', 'phpglfw-installer.php');" && sudo php phpglfw-installer.php
 
     - name: Install PHPUnit
-      run: composer require "phpunit/phpunit:9.6.3"
+      run: composer install"
     
     - name: Run PHPUnit 
       run: php vendor/bin/phpunit --exclude-group=glfwinit

--- a/.github/workflows/macos_installer.yml
+++ b/.github/workflows/macos_installer.yml
@@ -28,7 +28,7 @@ jobs:
       run: php -r "copy('https://raw.githubusercontent.com/mario-deluna/php-glfw/master/install/macos-installer.php', 'phpglfw-installer.php');" && sudo php phpglfw-installer.php
 
     - name: Install PHPUnit
-      run: composer install"
+      run: composer install
     
     - name: Run PHPUnit 
       run: php vendor/bin/phpunit --exclude-group=glfwinit

--- a/.github/workflows/static_cli.yml
+++ b/.github/workflows/static_cli.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.5']
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ['8.1', '8.2', '8.3', '8.4']
+          version: ['8.1', '8.2', '8.3', '8.4', '8.5']
           arch: [x64]
           ts: [ts, nts]
           # ts: [nts] # we are currently facing an issue on windows with the ZTS build, it crashes during the module initalisation 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0 || ^12.0"
+        "phpunit/phpunit": "9.6.34 || ^10.0 || ^11.0 || ^12.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.0 || ^10.0 || ^11.0 || ^12.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/generator/composer.json
+++ b/generator/composer.json
@@ -6,7 +6,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "nikic/php-parser": "^4.14"
     },

--- a/generator/phpunit.xml
+++ b/generator/phpunit.xml
@@ -5,9 +5,9 @@
       <directory suffix=".php">./tests/</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">./src</directory>
-    </whitelist>
-  </filter>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
+++ b/generator/src/PHPGlfwAdjustments/GLFWCreateWindowAdjustment.php
@@ -25,6 +25,10 @@ class GLFWCreateWindowAdjustment implements AdjustmentInterface
                 $b = parent::getFunctionImplementationBody() . PHP_EOL . PHP_EOL;
 
                 $b .= <<<EOD
+if (glfwwindow == NULL) {
+    RETURN_NULL();
+}
+
 // fetch the internal object
 phpglfw_glfwwindow_object *intern = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(return_value));
 

--- a/generator/templates/phpglfw_buffer.c.php
+++ b/generator/templates/phpglfw_buffer.c.php
@@ -752,7 +752,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     <?php echo $buffer->getClassEntryName(); ?>->get_iterator = <?php echo $buffer->getHandlerMethodName('get_iterator'); ?>;
 
 	zend_class_implements(<?php echo $buffer->getClassEntryName(); ?>, 1, phpglfw_buffer_interface_ce);
-    memcpy(&<?php echo $buffer->getHandlersVarName(); ?>, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&<?php echo $buffer->getHandlersVarName(); ?>, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     <?php echo $buffer->getHandlersVarName(); ?>.offset = XtOffsetOf(<?php echo $buffer->getObjectName(); ?>, std);
     
     <?php echo $buffer->getHandlersVarName(); ?>.free_obj = <?php echo $buffer->getHandlerMethodName('free'); ?>;

--- a/generator/templates/phpglfw_functions.c.php
+++ b/generator/templates/phpglfw_functions.c.php
@@ -206,7 +206,7 @@ void <?php echo $ipo->getObjectMinitHelperFunctionName(); ?>(void)
     <?php echo $ipo->getClassEntryName(); ?> = <?php echo $ipo->getClassRegistrationFunctionName(); ?>();
     <?php echo $ipo->getClassEntryName(); ?>->create_object = <?php echo $ipo->getObjectCreateFunctionName(); ?>;
 
-    memcpy(&<?php echo $ipo->getObjectHandlersVar(); ?>, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&<?php echo $ipo->getObjectHandlersVar(); ?>, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     <?php echo $ipo->getObjectHandlersVar(); ?>.clone_obj = NULL;
     <?php echo $ipo->getObjectHandlersVar(); ?>.free_obj = <?php echo $ipo->getObjectFreeFunctionName(); ?>;
     <?php echo $ipo->getObjectHandlersVar(); ?>.get_constructor = <?php echo $ipo->getClassConstructorFunctionName(); ?>;

--- a/generator/templates/phpglfw_vg.c.php
+++ b/generator/templates/phpglfw_vg.c.php
@@ -991,7 +991,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcontext_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgcontext_ce->create_object = phpglfw_vgcontext_create_handler;
 
-    memcpy(&phpglfw_vgcontext_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgcontext_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgcontext_handlers.offset = XtOffsetOf(phpglfw_vgcontext_object, std);
     phpglfw_vgcontext_handlers.free_obj = phpglfw_vgcontext_free_handler;
 
@@ -1022,7 +1022,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcolor_ce->serialize = phpglfw_vgcolor_serialize_handler;
     phpglfw_vgcolor_ce->unserialize = phpglfw_vgcolor_unserialize_handler;
 
-    memcpy(&phpglfw_vgcolor_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgcolor_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgcolor_handlers.offset = XtOffsetOf(phpglfw_vgcolor_object, std);
     phpglfw_vgcolor_handlers.free_obj = phpglfw_vgcolor_free_handler;
     phpglfw_vgcolor_handlers.get_debug_info = phpglfw_vgcolor_debug_info_handler;
@@ -1034,7 +1034,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgimage_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgimage_ce->create_object = phpglfw_vgimage_create_handler;
 
-    memcpy(&phpglfw_vgimage_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgimage_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgimage_handlers.offset = XtOffsetOf(phpglfw_vgimage_object, std);
     phpglfw_vgimage_handlers.free_obj = phpglfw_vgimage_free_handler;
 
@@ -1065,7 +1065,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgpaint_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgpaint_ce->create_object = phpglfw_vgpaint_create_handler;
 
-    memcpy(&phpglfw_vgpaint_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgpaint_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgpaint_handlers.offset = XtOffsetOf(phpglfw_vgpaint_object, std);
     phpglfw_vgpaint_handlers.free_obj = phpglfw_vgpaint_free_handler;
     phpglfw_vgpaint_handlers.get_debug_info = phpglfw_vgpaint_debug_info_handler;

--- a/phpglfw.h
+++ b/phpglfw.h
@@ -34,7 +34,7 @@ PHP_MINFO_FUNCTION(glfw);
 PHP_MSHUTDOWN_FUNCTION(glfw);
 
 ZEND_BEGIN_MODULE_GLOBALS(glfw)
-    zend_bool buffer_serialize_hex_float;
+    bool buffer_serialize_hex_float;
 ZEND_END_MODULE_GLOBALS(glfw)
 
 ZEND_EXTERN_MODULE_GLOBALS(glfw)

--- a/phpglfw_audio.c
+++ b/phpglfw_audio.c
@@ -500,7 +500,7 @@ PHP_METHOD(GL_Audio_Sound, setPitch)
 
 PHP_METHOD(GL_Audio_Sound, setLoop)
 {
-    zend_bool loop;
+    bool loop;
     if (zend_parse_parameters(ZEND_NUM_ARGS() , "b", &loop) == FAILURE) {
         RETURN_THROWS();
     }

--- a/phpglfw_buffer.c
+++ b/phpglfw_buffer.c
@@ -4928,7 +4928,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glfloat_ce->get_iterator = phpglfw_buffer_glfloat_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glfloat_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glfloat_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glfloat_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glfloat_handlers.offset = XtOffsetOf(phpglfw_buffer_glfloat_object, std);
     
     phpglfw_buffer_glfloat_handlers.free_obj = phpglfw_buffer_glfloat_free_handler;
@@ -4945,7 +4945,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glhalf_ce->get_iterator = phpglfw_buffer_glhalf_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glhalf_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glhalf_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glhalf_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glhalf_handlers.offset = XtOffsetOf(phpglfw_buffer_glhalf_object, std);
     
     phpglfw_buffer_glhalf_handlers.free_obj = phpglfw_buffer_glhalf_free_handler;
@@ -4962,7 +4962,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_gldouble_ce->get_iterator = phpglfw_buffer_gldouble_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_gldouble_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_gldouble_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_gldouble_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_gldouble_handlers.offset = XtOffsetOf(phpglfw_buffer_gldouble_object, std);
     
     phpglfw_buffer_gldouble_handlers.free_obj = phpglfw_buffer_gldouble_free_handler;
@@ -4979,7 +4979,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glint_ce->get_iterator = phpglfw_buffer_glint_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glint_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glint_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glint_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glint_handlers.offset = XtOffsetOf(phpglfw_buffer_glint_object, std);
     
     phpglfw_buffer_glint_handlers.free_obj = phpglfw_buffer_glint_free_handler;
@@ -4996,7 +4996,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_gluint_ce->get_iterator = phpglfw_buffer_gluint_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_gluint_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_gluint_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_gluint_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_gluint_handlers.offset = XtOffsetOf(phpglfw_buffer_gluint_object, std);
     
     phpglfw_buffer_gluint_handlers.free_obj = phpglfw_buffer_gluint_free_handler;
@@ -5013,7 +5013,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glshort_ce->get_iterator = phpglfw_buffer_glshort_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glshort_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glshort_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glshort_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glshort_handlers.offset = XtOffsetOf(phpglfw_buffer_glshort_object, std);
     
     phpglfw_buffer_glshort_handlers.free_obj = phpglfw_buffer_glshort_free_handler;
@@ -5030,7 +5030,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glushort_ce->get_iterator = phpglfw_buffer_glushort_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glushort_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glushort_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glushort_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glushort_handlers.offset = XtOffsetOf(phpglfw_buffer_glushort_object, std);
     
     phpglfw_buffer_glushort_handlers.free_obj = phpglfw_buffer_glushort_free_handler;
@@ -5047,7 +5047,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glbyte_ce->get_iterator = phpglfw_buffer_glbyte_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glbyte_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glbyte_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glbyte_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glbyte_handlers.offset = XtOffsetOf(phpglfw_buffer_glbyte_object, std);
     
     phpglfw_buffer_glbyte_handlers.free_obj = phpglfw_buffer_glbyte_free_handler;
@@ -5064,7 +5064,7 @@ void phpglfw_register_buffer_module(INIT_FUNC_ARGS)
     phpglfw_buffer_glubyte_ce->get_iterator = phpglfw_buffer_glubyte_get_iterator_handler;
 
 	zend_class_implements(phpglfw_buffer_glubyte_ce, 1, phpglfw_buffer_interface_ce);
-    memcpy(&phpglfw_buffer_glubyte_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_buffer_glubyte_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_buffer_glubyte_handlers.offset = XtOffsetOf(phpglfw_buffer_glubyte_object, std);
     
     phpglfw_buffer_glubyte_handlers.free_obj = phpglfw_buffer_glubyte_free_handler;

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -170,7 +170,7 @@ void phpglfw_glfwwindow_object_minit_helper(void)
     phpglfw_glfwwindow_ce = phpglfw_glfwwindow_class_register();
     phpglfw_glfwwindow_ce->create_object = phpglfw_glfwwindow_object_create;
 
-    memcpy(&phpglfw_glfwwindow_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_glfwwindow_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_glfwwindow_object_handlers.clone_obj = NULL;
     phpglfw_glfwwindow_object_handlers.free_obj = phpglfw_glfwwindow_object_free;
     phpglfw_glfwwindow_object_handlers.get_constructor = phpglfw_glfwwindow_class_constructor;
@@ -255,7 +255,7 @@ void phpglfw_glfwmonitor_object_minit_helper(void)
     phpglfw_glfwmonitor_ce = phpglfw_glfwmonitor_class_register();
     phpglfw_glfwmonitor_ce->create_object = phpglfw_glfwmonitor_object_create;
 
-    memcpy(&phpglfw_glfwmonitor_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_glfwmonitor_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_glfwmonitor_object_handlers.clone_obj = NULL;
     phpglfw_glfwmonitor_object_handlers.free_obj = phpglfw_glfwmonitor_object_free;
     phpglfw_glfwmonitor_object_handlers.get_constructor = phpglfw_glfwmonitor_class_constructor;
@@ -340,7 +340,7 @@ void phpglfw_glfwcursor_object_minit_helper(void)
     phpglfw_glfwcursor_ce = phpglfw_glfwcursor_class_register();
     phpglfw_glfwcursor_ce->create_object = phpglfw_glfwcursor_object_create;
 
-    memcpy(&phpglfw_glfwcursor_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_glfwcursor_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_glfwcursor_object_handlers.clone_obj = NULL;
     phpglfw_glfwcursor_object_handlers.free_obj = phpglfw_glfwcursor_object_free;
     phpglfw_glfwcursor_object_handlers.get_constructor = phpglfw_glfwcursor_class_constructor;
@@ -495,7 +495,7 @@ void phpglfw_glfwvidmode_object_minit_helper(void)
     phpglfw_glfwvidmode_ce = phpglfw_glfwvidmode_class_register();
     phpglfw_glfwvidmode_ce->create_object = phpglfw_glfwvidmode_object_create;
 
-    memcpy(&phpglfw_glfwvidmode_object_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_glfwvidmode_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_glfwvidmode_object_handlers.clone_obj = NULL;
     phpglfw_glfwvidmode_object_handlers.free_obj = phpglfw_glfwvidmode_object_free;
     phpglfw_glfwvidmode_object_handlers.get_constructor = phpglfw_glfwvidmode_class_constructor;

--- a/phpglfw_functions.c
+++ b/phpglfw_functions.c
@@ -10940,6 +10940,9 @@ PHP_FUNCTION(glfwCreateWindow)
         share = phpglfw_glfwwindowptr_from_zval_ptr(share_zval);
     }
     GLFWwindow* glfwwindow = glfwCreateWindow(width, height, title, monitor, share);
+    if (glfwwindow == NULL) {
+        RETURN_NULL();
+    }
     phpglfw_glfwwindow_ptr_assign_to_zval_p(return_value, glfwwindow);
     // fetch the internal object
     phpglfw_glfwwindow_object *intern = phpglfw_glfwwindow_objectptr_from_zobj_p(Z_OBJ_P(return_value));

--- a/phpglfw_texture.c
+++ b/phpglfw_texture.c
@@ -501,7 +501,7 @@ void phpglfw_register_texture_module(INIT_FUNC_ARGS)
     zend_declare_class_constant_long(phpglfw_texture2d_ce, "CHANNEL_RGB", strlen("CHANNEL_RGB"), 3);
     zend_declare_class_constant_long(phpglfw_texture2d_ce, "CHANNEL_RGBA", strlen("CHANNEL_RGBA"), 4);
 
-    memcpy(&phpglfw_texture2d_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_texture2d_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_texture2d_handlers.offset = XtOffsetOf(phpglfw_texture2d_object, std);
     phpglfw_texture2d_handlers.free_obj = phpglfw_texture2d_free_handler;
     phpglfw_texture2d_handlers.get_debug_info = phpglfw_texture2d_debug_info_handler;

--- a/phpglfw_vg.c
+++ b/phpglfw_vg.c
@@ -1994,7 +1994,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcontext_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgcontext_ce->create_object = phpglfw_vgcontext_create_handler;
 
-    memcpy(&phpglfw_vgcontext_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgcontext_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgcontext_handlers.offset = XtOffsetOf(phpglfw_vgcontext_object, std);
     phpglfw_vgcontext_handlers.free_obj = phpglfw_vgcontext_free_handler;
 
@@ -2025,7 +2025,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgcolor_ce->serialize = phpglfw_vgcolor_serialize_handler;
     phpglfw_vgcolor_ce->unserialize = phpglfw_vgcolor_unserialize_handler;
 
-    memcpy(&phpglfw_vgcolor_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgcolor_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgcolor_handlers.offset = XtOffsetOf(phpglfw_vgcolor_object, std);
     phpglfw_vgcolor_handlers.free_obj = phpglfw_vgcolor_free_handler;
     phpglfw_vgcolor_handlers.get_debug_info = phpglfw_vgcolor_debug_info_handler;
@@ -2037,7 +2037,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgimage_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgimage_ce->create_object = phpglfw_vgimage_create_handler;
 
-    memcpy(&phpglfw_vgimage_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgimage_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgimage_handlers.offset = XtOffsetOf(phpglfw_vgimage_object, std);
     phpglfw_vgimage_handlers.free_obj = phpglfw_vgimage_free_handler;
 
@@ -2068,7 +2068,7 @@ void phpglfw_register_vg_module(INIT_FUNC_ARGS)
     phpglfw_vgpaint_ce = zend_register_internal_class(&tmp_ce);
     phpglfw_vgpaint_ce->create_object = phpglfw_vgpaint_create_handler;
 
-    memcpy(&phpglfw_vgpaint_handlers, &std_object_handlers, sizeof(zend_object_handlers));
+    memcpy(&phpglfw_vgpaint_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     phpglfw_vgpaint_handlers.offset = XtOffsetOf(phpglfw_vgpaint_object, std);
     phpglfw_vgpaint_handlers.free_obj = phpglfw_vgpaint_free_handler;
     phpglfw_vgpaint_handlers.get_debug_info = phpglfw_vgpaint_debug_info_handler;

--- a/phpglfw_voxparser.c
+++ b/phpglfw_voxparser.c
@@ -49,7 +49,7 @@ void phpglfw_voxparser_transform_to_mat4(zval *mat4_zval, const ogt_vox_transfor
 phpglfw_buffer_glubyte_object *phpglfw_voxparser_palette_ensure_buffer(phpglfw_voxparser_palette_object *palette_intern);
 void phpglfw_voxparser_palette_prepare_buffer(phpglfw_buffer_glubyte_object *buffer_intern);
 void phpglfw_voxparser_palette_copy_from_rgba(phpglfw_buffer_glubyte_object *buffer_intern, const ogt_vox_rgba_c *rgba);
-zend_bool phpglfw_voxparser_palette_extract_color(zval *color_zval, uint8_t *rgba_out);
+bool phpglfw_voxparser_palette_extract_color(zval *color_zval, uint8_t *rgba_out);
 uint8_t phpglfw_vox_float_to_byte(double value);
 
 zend_class_entry *phpglfw_voxparser_res_ce;
@@ -98,7 +98,7 @@ static const ogt_vox_rgba_c* phpglfw_vox_default_palette(void)
     return palette;
 }
 
-static zend_bool phpglfw_vox_mesh_mode_from_zval(zval *mode_zval, phpglfw_vox_mesh_mode *out_mode)
+static bool phpglfw_vox_mesh_mode_from_zval(zval *mode_zval, phpglfw_vox_mesh_mode *out_mode)
 {
     if (!mode_zval || !out_mode) {
         return 0;
@@ -415,8 +415,8 @@ void create_instances_phparray(zval *array_zval, const ogt_vox_scene_wrapper* sc
 
         ogt_vox_transform_c transform_global;
         ogt_vox_transform_c transform_local;
-        zend_bool have_global = ogt_vox_scene_get_instance_transform_global(scene, i, &transform_global);
-        zend_bool have_local = ogt_vox_scene_get_instance_transform_local(scene, i, &transform_local);
+        bool have_global = ogt_vox_scene_get_instance_transform_global(scene, i, &transform_global);
+        bool have_local = ogt_vox_scene_get_instance_transform_local(scene, i, &transform_local);
 
         instance_intern->has_transforms = have_global || have_local;
         if (have_global) {
@@ -539,8 +539,8 @@ void create_groups_phparray(zval *array_zval, const ogt_vox_scene_wrapper* scene
 
         ogt_vox_transform_c transform_global;
         ogt_vox_transform_c transform_local;
-        zend_bool have_global = ogt_vox_scene_get_group_transform_global(scene, i, &transform_global);
-        zend_bool have_local = ogt_vox_scene_get_group_transform_local(scene, i, &transform_local);
+        bool have_global = ogt_vox_scene_get_group_transform_global(scene, i, &transform_global);
+        bool have_local = ogt_vox_scene_get_group_transform_local(scene, i, &transform_local);
 
         group_intern->has_transforms = have_global || have_local;
 
@@ -959,7 +959,7 @@ PHP_METHOD(GL_Geometry_VoxFileParser_Palette, replaceFromArray)
     phpglfw_buffer_glubyte_object *buffer_intern = phpglfw_voxparser_palette_ensure_buffer(intern);
 
     HashTable *ht = Z_ARRVAL_P(colors_zval);
-    zend_bool updated = 0;
+    bool updated = 0;
     zval *color_entry;
     zend_ulong index_key;
 
@@ -1055,7 +1055,7 @@ PHP_METHOD(GL_Geometry_VoxFileParser_Model, generateTriangleMesh)
         PHPGLFW_VOX_COLOR_LAYOUT_NONE
     } color_mode = PHPGLFW_VOX_COLOR_LAYOUT_RGB;
 
-    zend_bool include_palette_index = 0;
+    bool include_palette_index = 0;
     enum {
         PHPGLFW_VOX_ORIGIN_CORNER,
         PHPGLFW_VOX_ORIGIN_CENTER
@@ -1381,7 +1381,7 @@ void phpglfw_voxparser_palette_copy_from_rgba(phpglfw_buffer_glubyte_object *buf
     memcpy(buffer_intern->vec, rgba, PHPGLFW_VOX_PALETTE_BYTES);
 }
 
-zend_bool phpglfw_voxparser_palette_extract_color(zval *color_zval, uint8_t *rgba_out)
+bool phpglfw_voxparser_palette_extract_color(zval *color_zval, uint8_t *rgba_out)
 {
     if (Z_TYPE_P(color_zval) == IS_ARRAY) {
         HashTable *ht = Z_ARRVAL_P(color_zval);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit colors="true" bootstrap="phpunit.php">
   <testsuites>
     <testsuite name="Hydrogen App">
-      <directory suffix=".php">./tests/</directory>
+      <directory suffix="Test.php">./tests/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/tests/GLFunctions/GetAndSetParamtersTest.php
+++ b/tests/GLFunctions/GetAndSetParamtersTest.php
@@ -5,6 +5,7 @@ namespace GL\Tests\GLFunctions;
 /**
  * @group glfwinit
  */
+#[\PHPUnit\Framework\Attributes\Group('glfwinit')]
 class GetAndSetParamtersTest extends GLFunctionsTestCase
 {
     public function testGlEnableDisable()

--- a/tests/GLFunctions/GetAndSetParamtersTest.php
+++ b/tests/GLFunctions/GetAndSetParamtersTest.php
@@ -2,10 +2,6 @@
 
 namespace GL\Tests\GLFunctions;
 
-use GLFWwindow;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
-use PHPUnit\Framework\ExpectationFailedException;
-
 /**
  * @group glfwinit
  */

--- a/tests/GLFunctions/ShderCompilationTest.php
+++ b/tests/GLFunctions/ShderCompilationTest.php
@@ -5,6 +5,7 @@ namespace GL\Tests\GLFunctions;
 /**
  * @group glfwinit
  */
+#[\PHPUnit\Framework\Attributes\Group('glfwinit')]
 class ShderCompilationTest extends GLFunctionsTestCase
 {
     public function testShaderCompilation()

--- a/tests/GLFunctions/ShderCompilationTest.php
+++ b/tests/GLFunctions/ShderCompilationTest.php
@@ -2,10 +2,6 @@
 
 namespace GL\Tests\GLFunctions;
 
-use GLFWwindow;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
-use PHPUnit\Framework\ExpectationFailedException;
-
 /**
  * @group glfwinit
  */


### PR DESCRIPTION
  Title: Add PHP 8.5 compatibility
                                                                                                                                                                       
  Summary                                                                                                                                                            

  - Replace all zend_bool usage with native C bool type, as zend_bool typedef is removed in PHP 8.5
  - Replace deprecated direct &std_object_handlers access with zend_get_std_object_handlers() across all modules
  - Update generator templates to ensure future code generation preserves these fixes

  Details

  Both changes are backwards-compatible with PHP 8.0+:
  - bool is available via stdbool.h included through Zend headers in all PHP 8.x versions
  - zend_get_std_object_handlers() has been available since PHP 8.0

  Files changed

  Hand-written sources:
  - phpglfw.h — module global type fix
  - phpglfw.c — INI entry (no change needed, OnUpdateBool works with bool)
  - phpglfw_audio.c — setLoop() parameter type
  - phpglfw_voxparser.c — 8 occurrences across function signatures and local variables
  - phpglfw_texture.c — object handler initialization

  Generated sources:
  - phpglfw_buffer.c — 9 buffer type handler initializations
  - phpglfw_functions.c — 4 GLFW object handler initializations
  - phpglfw_vg.c — 4 VG object handler initializations

  Generator templates (prevents regression on re-generation):
  - generator/templates/phpglfw_buffer.c.php
  - generator/templates/phpglfw_functions.c.php
  - generator/templates/phpglfw_vg.c.php

  Test plan

  - Build and run tests on PHP 8.1–8.4 (no regressions)
  - Build and run tests on PHP 8.5